### PR TITLE
Add gemini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ before_install:
 
 install:
   - $SCRIPT_DIR/travis_setup.sh
-  - for D in $TRAVIS_BUILD_DIR/; do (cd D; composer install) done
+  - for D in $TRAVIS_BUILD_DIR/; do (cd $D; composer install) done
 
 script:
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
-  - for D in $TRAVIS_BUILD_DIR/; do (cd D; vendor/bin/phpcs --standard=PSR2 src tests) done
-  - for D in $TRAVIS_BUILD_DIR/; do (cd D; vendor/bin/phpcpd --names *.php src) done
-  - for D in $TRAVIS_BUILD_DIR/; do (cd D; vendor/bin/phpunit --verbose) done
+  - for D in $TRAVIS_BUILD_DIR/; do (cd $D; vendor/bin/phpcs --standard=PSR2 src tests) done
+  - for D in $TRAVIS_BUILD_DIR/; do (cd $D; vendor/bin/phpcpd --names *.php src) done
+  - for D in $TRAVIS_BUILD_DIR/; do (cd $D; vendor/bin/phpunit --verbose) done
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ before_install:
 
 install:
   - $SCRIPT_DIR/travis_setup.sh
-  - for D in $TRAVIS_BUILD_DIR/; do (cd $D; composer install) done
+  - for D in */; do (cd $D; composer install) done
 
 script:
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
-  - for D in $TRAVIS_BUILD_DIR/; do (cd $D; vendor/bin/phpcs --standard=PSR2 src tests) done
-  - for D in $TRAVIS_BUILD_DIR/; do (cd $D; vendor/bin/phpcpd --names *.php src) done
-  - for D in $TRAVIS_BUILD_DIR/; do (cd $D; vendor/bin/phpunit --verbose) done
+  - for D in */; do (cd $D; vendor/bin/phpcs --standard=PSR2 src tests) done
+  - for D in */; do (cd $D; vendor/bin/phpcpd --names *.php src) done
+  - for D in */; do (cd $D; vendor/bin/phpunit --verbose) done
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ before_install:
 
 install:
   - $SCRIPT_DIR/travis_setup.sh
-  - cd Hypercube; composer install
+  - for D in $TRAVIS_BUILD_DIR/; do (cd D; composer install) done
 
 script:
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
-  - cd $TRAVIS_BUILD_DIR/Hypercube; vendor/bin/phpcs --standard=PSR2 src tests
-  - cd $TRAVIS_BUILD_DIR/Hypercube; vendor/bin/phpcpd --names *.php src
-  - cd $TRAVIS_BUILD_DIR/Hypercube; vendor/bin/phpunit --verbose
+  - for D in $TRAVIS_BUILD_DIR/; do (cd D; vendor/bin/phpcs --standard=PSR2 src tests) done
+  - for D in $TRAVIS_BUILD_DIR/; do (cd D; vendor/bin/phpcpd --names *.php src) done
+  - for D in $TRAVIS_BUILD_DIR/; do (cd D; vendor/bin/phpunit --verbose) done
 
 notifications:
   irc:

--- a/Gemini/.gitignore
+++ b/Gemini/.gitignore
@@ -1,0 +1,6 @@
+/phpunit.xml
+/vendor
+/build
+/composer.lock
+.idea
+

--- a/Gemini/README.md
+++ b/Gemini/README.md
@@ -1,0 +1,95 @@
+# Gemini 
+[![Contribution Guidelines][2]](./CONTRIBUTING.md)
+[![LICENSE][3]](./LICENSE)
+
+## Introduction
+
+A path mapping service for Islandora-CLAW.  Gemini is what links content created in Drupal to data stored in Fedora.  It has a very simple API and is built on top of a relational database using Doctrine's [database abstreaction layer][4].
+
+## Installation
+
+- Install the database of your choice that is [compatible with Doctrine's DBAL][5]. 
+- Clone this repository.
+- Install `composer`.  [Install instructions here.][6]
+- `$ cd /path/to/Gemini` and run `$ composer install`
+- Then either
+  - For production, configure your web server appropriately (e.g. add a VirtualHost for Gemini in Apache) OR
+  - For development, run the PHP built-in webserver `$ php -S localhost:8888 -t src` from Gemini root.
+
+Gemini runs on its own database, and requires one table.  You'll need to set that up manually.  For example, using MySQL:
+```mysql
+create database gemini;
+CREATE TABLE gemini.Gemini (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    drupal VARCHAR(2048) NOT NULL UNIQUE,
+    fedora VARCHAR(2048) NOT NULL UNIQUE
+) ENGINE=InnoDB;
+```
+
+## Configuration
+
+Gemini accepts [configuration for Doctrine's DBAL](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html) as the `db.options` array in [its config file](./cfg/cfg.php) file.  Reasonable defaults provided are for a MySQL installation.  Do not commit the configuration file with your credentials into Git!
+
+## Usage
+
+Gemini's links url paths (excluding base urls) between Drupal and Fedora.  Assuming you have a FedoraResource entity in Drupal at `http://localhost:8000/fedora_resource/1` and an RdfSource in Fedora at `http://localhost:8080/fcrepo/rest/foo/bar`:
+
+#### POST /
+To link two resources, one must POST a JSON message that conforms to this format:
+```
+{
+  "drupal" : "path/in/drupal",
+  "fedora" : "path/in/fedora"
+}
+```
+For example, with the resources described above:
+```
+$ curl -X POST -H "Content-Type: application/json" -d '{"drupal" : "fedora_resource/1", "fedora" : "foo/bar"}' "localhost:8888/"
+```
+will return 201 on success.
+
+Once linked, the following operations are available to retrieve and delete information in Gemini.
+
+#### GET drupal/path/to/resource 
+For example, with the resources described above:
+```
+curl "http://localhost:8888/drupal/fedora_resource/1"
+```
+returns `foo/bar`.
+
+#### GET fedora/path/to/resource 
+For example, with the resources described above:
+```
+curl "http://localhost:8888/fedora/foo/bar"
+```
+returns `fedora_resource/1`.
+
+#### DELETE drupal/path/to/resource
+For example, with the resources described above:
+```
+curl -X DELETE "http://localhost:8888/drupal/fedora_resource/1"
+```
+will unlink the two entities.
+
+#### DELETE fedora/path/to/resource
+For example, with the resources described above:
+```
+curl -X DELETE "http://localhost:8888/fedora/foo/bar"
+```
+will unlink the two entities.
+
+## Maintainers
+
+Current maintainers:
+
+* [Daniel Lamb](https://github.com/dannylamb)
+
+## License
+
+[MIT](http://www.gnu.org/licenses/gpl-2.0.txt)
+
+[2]: http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg
+[3]: https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square
+[4]: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/
+[5]: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/introduction.html
+[6]: https://getcomposer.org/download/

--- a/Gemini/cfg/cfg.php
+++ b/Gemini/cfg/cfg.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'db.options' => [
+        'driver' => 'pdo_mysql',
+        'host' => '127.0.0.1',
+        'port' => 3306,
+        'dbname' => 'gemini',
+        'user' => 'changeme',
+        'password' => 'changeme',
+    ],
+];

--- a/Gemini/composer.json
+++ b/Gemini/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "islandora/gemini",
+    "description": "ID Mapping Service between Fedora and Drupalf or Islandora",
+    "require": {
+        "silex/silex": "^2.0",
+        "doctrine/dbal": "~2.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.0",
+        "squizlabs/php_codesniffer": "^2.0",
+        "sebastian/phpcpd": "^3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Islandora\\Gemini\\": "src/"
+        }
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Daniel Lamb",
+            "email": "dlamb@islandora.ca"
+        }
+    ]
+}

--- a/Gemini/composer.json
+++ b/Gemini/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "islandora/gemini",
-    "description": "ID Mapping Service between Fedora and Drupalf or Islandora",
+    "description": "Path mapping Service between Fedora and Drupal",
     "require": {
         "silex/silex": "^2.0",
         "doctrine/dbal": "~2.2"
@@ -18,8 +18,14 @@
     "license": "MIT",
     "authors": [
         {
+            "name": "Islandora Foundation",
+            "email": "community@islandora.ca",
+            "role": "Owner"
+        },
+        {
             "name": "Daniel Lamb",
-            "email": "dlamb@islandora.ca"
+            "email": "dlamb@islandora.ca",
+            "role": "Maintainer"
         }
     ]
 }

--- a/Gemini/phpunit.xml.dist
+++ b/Gemini/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Gemini Tests">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/Gemini/src/Controller/GeminiController.php
+++ b/Gemini/src/Controller/GeminiController.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Islandora\Gemini\Controller;
+
+use Islandora\Gemini\Service\GeminiServiceInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class GeminiController
+ * @package Islandora\Gemini\Controller
+ */
+class GeminiController
+{
+
+    /**
+     * @var \Islandora\Gemini\Service\GeminiServiceInterface
+     */
+    protected $gemini;
+
+    /**
+     * GeminiController constructor.
+     * @param \Islandora\Gemini\Service\GeminiServiceInterface $gemini
+     */
+    public function __construct(GeminiServiceInterface $gemini)
+    {
+        $this->gemini = $gemini;
+    }
+
+    /**
+     * @param string $fedora_path
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getDrupalPath($fedora_path)
+    {
+        try {
+            if (!$result = $this->gemini->getDrupalPath($fedora_path)) {
+                return new Response(null, 404);
+            }
+
+            return new Response($result, 200);
+        } catch (\Exception $e) {
+            return new Response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @param string $drupal_path
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getFedoraPath($drupal_path)
+    {
+        try {
+            if (!$result = $this->gemini->getFedoraPath($drupal_path)) {
+                return new Response(null, 404);
+            }
+
+            return new Response($result, 200);
+        } catch (\Exception $e) {
+            return new Response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function createPair(Request $request)
+    {
+        $content_type = $request->headers->get("Content-Type");
+        if (strcmp($content_type, "application/json") != 0) {
+            return new Response("POST only accepts json requests", 400);
+        }
+
+        $body = json_decode($request->getContent(), true);
+
+        if (!isset($body['drupal'])) {
+            return new Response("POST body must contain Drupal path", 400);
+        }
+
+        if (!isset($body['fedora'])) {
+            return new Response("POST body must contain Fedora path", 400);
+        }
+
+        try {
+            $this->gemini->createPair(
+                $body['drupal'],
+                $body['fedora']
+            );
+             return new Response(null, 201);
+        } catch (\Exception $e) {
+            return new Response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @param string $drupal_path
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function deleteFromDrupalPath($drupal_path)
+    {
+        try {
+            if (!$result = $this->gemini->deleteFromDrupalPath($drupal_path)) {
+                return new Response("Not Found", 404);
+            }
+
+            return new Response(null, 204);
+        } catch (\Exception $e) {
+            return new Response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @param string $fedora_path
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function deleteFromFedoraPath($fedora_path)
+    {
+        try {
+            if (!$result = $this->gemini->deleteFromFedoraPath($fedora_path)) {
+                return new Response(null, 404);
+            }
+
+            return new Response(null, 204);
+        } catch (\Exception $e) {
+            return new Response($e->getMessage(), 500);
+        }
+    }
+}

--- a/Gemini/src/Service/GeminiService.php
+++ b/Gemini/src/Service/GeminiService.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Islandora\Gemini\Service;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Class GeminiService
+ * @package Islandora\Gemini\Service
+ */
+class GeminiService implements GeminiServiceInterface
+{
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    /**
+     * GeminiService constructor.
+     * @param \Doctrine\DBAL\Connection $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFedoraPath($drupal_path)
+    {
+        $sql = "SELECT fedora FROM Gemini WHERE drupal = :path";
+        $stmt = $this->connection->executeQuery(
+            $sql,
+            ['path' => $drupal_path]
+        );
+        $result = $stmt->fetch();
+
+        if (isset($result['fedora'])) {
+            return $result['fedora'];
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDrupalPath($fedora_path)
+    {
+        $sql = "SELECT drupal FROM Gemini WHERE fedora = :path";
+        $stmt = $this->connection->executeQuery(
+            $sql,
+            ['path' => $fedora_path]
+        );
+        $result = $stmt->fetch();
+
+        if (isset($result['drupal'])) {
+            return $result['drupal'];
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createPair($drupal_path, $fedora_path)
+    {
+        $this->connection->insert(
+            'Gemini',
+            ['drupal' => $drupal_path, 'fedora' => $fedora_path]
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deleteFromDrupalPath($drupal_path)
+    {
+        return $this->connection->delete(
+            'Gemini',
+            ['drupal' => $drupal_path]
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deleteFromFedoraPath($fedora_path)
+    {
+        return $this->connection->delete(
+            'Gemini',
+            ['fedora' => $fedora_path]
+        );
+    }
+}

--- a/Gemini/src/Service/GeminiServiceInterface.php
+++ b/Gemini/src/Service/GeminiServiceInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Islandora\Gemini\Service;
+
+/**
+ * Interface GeminiServiceInterface
+ * @package Islandora\Gemini\Service
+ */
+interface GeminiServiceInterface
+{
+    /**
+     * @param string $fedora_path
+     * @return mixed string|null
+     * @throws \Exception
+     */
+    public function getDrupalPath($fedora_path);
+
+    /**
+     * @param string $drupal_path
+     * @return mixed string|null
+     * @throws \Exception
+     */
+    public function getFedoraPath($drupal_path);
+
+    /**
+     * @param string $drupal_path
+     * @param string $fedora_path
+     * @throws \Exception
+     */
+    public function createPair($drupal_path, $fedora_path);
+
+    /**
+     * @param string $drupal_path
+     * @return boolean
+     * @throws \Exception
+     */
+    public function deleteFromDrupalPath($drupal_path);
+
+    /**
+     * @param string $fedora_path
+     * @return boolean
+     * @throws \Exception
+     */
+    public function deleteFromFedoraPath($fedora_path);
+}

--- a/Gemini/src/app.php
+++ b/Gemini/src/app.php
@@ -1,0 +1,33 @@
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+use Islandora\Gemini\Service\GeminiService;
+use Islandora\Gemini\Controller\GeminiController;
+use Silex\Application;
+use Silex\Provider\DoctrineServiceProvider;
+use Silex\Provider\ServiceControllerServiceProvider;
+
+$config = require_once(__DIR__ . '/../cfg/cfg.php');
+
+$app = new Application();
+$app->register(new ServiceControllerServiceProvider());
+$app->register(new DoctrineServiceProvider(), ['db.options' => $config['db.options']]);
+
+$app['gemini.controller'] = function () use ($app) {
+    return new GeminiController(
+        new GeminiService($app['db'])
+    );
+};
+
+$app->get('/drupal/{drupal_path}', "gemini.controller:getFedoraPath")
+    ->assert("drupal_path", ".+");
+$app->get('/fedora/{fedora_path}', "gemini.controller:getDrupalPath")
+    ->assert("fedora_path", ".+");
+$app->post('/', "gemini.controller:createPair");
+$app->delete("/drupal/{drupal_path}", "gemini.controller:deleteFromDrupalPath")
+    ->assert("drupal_path", ".+");
+$app->delete("/fedora/{fedora_path}", "gemini.controller:deleteFromFedoraPath")
+    ->assert("fedora_path", ".+");
+
+return $app;

--- a/Gemini/src/index.php
+++ b/Gemini/src/index.php
@@ -1,0 +1,4 @@
+<?php
+
+$app = require_once(__DIR__ . '/app.php');
+$app->run();

--- a/Gemini/tests/Islandora/Gemini/Tests/CreatePairTest.php
+++ b/Gemini/tests/Islandora/Gemini/Tests/CreatePairTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Drupal\Gemini\Tests;
+
+use Islandora\Gemini\Controller\GeminiController;
+use Islandora\Gemini\Service\GeminiService;
+use Symfony\Component\HttpFoundation\Request;
+
+class CreatePairTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturns500OnException()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $prophecy->createPair("http://foo.com/bar", "http://baz.com/boo")
+            ->willThrow(new \Exception("Exception", 500));
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $request = Request::create(
+            "/",
+            "POST",
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{"drupal" : "http://foo.com/bar", "fedora" : "http://baz.com/boo"}'
+        );
+
+        $response = $controller->createPair($request);
+
+        $this->assertTrue(
+            $response->getStatusCode() == 500,
+            "Response must be 500 when Exception occurs"
+        );
+    }
+
+    public function testReturns400OnMalformedRequest()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->createPair(Request::create(
+            "/",
+            "POST",
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json']
+        ));
+
+        $this->assertTrue(
+            $response->getStatusCode() == 400,
+            "Expected 400 if empty POST body"
+        );
+
+        $response = $controller->createPair(Request::create(
+            "/",
+            "POST",
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{"foo" : "bar"}'
+        ));
+
+        $this->assertTrue(
+            $response->getStatusCode() == 400,
+            "Expected 400 if POST contains neither Drupal nor Fedora uris"
+        );
+
+        $response = $controller->createPair(Request::create(
+            "/",
+            "POST",
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{"drupal" : "http://foo.com/bar"}'
+        ));
+
+        $this->assertTrue(
+            $response->getStatusCode() == 400,
+            "Expected 400 if POST does not contain Fedora uri"
+        );
+
+        $response = $controller->createPair(Request::create(
+            "/",
+            "POST",
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{"fedora" : "http://baz.com/boo"}'
+        ));
+
+        $this->assertTrue(
+            $response->getStatusCode() == 400,
+            "Expected 400 if POST does not contain Drupal uri"
+        );
+    }
+
+    public function testReturns201OnCreation()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $request = Request::create(
+            "/",
+            "POST",
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{"drupal" : "http://foo.com/bar", "fedora" : "http://baz.com/boo"}'
+        );
+
+        $response = $controller->createPair($request);
+
+        $this->assertTrue(
+            $response->getStatusCode() == 201,
+            "Response must be 500 on success"
+        );
+    }
+}

--- a/Gemini/tests/Islandora/Gemini/Tests/DeleteFromDrupalPathTest.php
+++ b/Gemini/tests/Islandora/Gemini/Tests/DeleteFromDrupalPathTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Islandora\Gemini\Tests;
+
+use Islandora\Gemini\Controller\GeminiController;
+use Islandora\Gemini\Service\GeminiService;
+
+class DeleteFromDrupalPathTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturns500OnException()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $prophecy->deleteFromDrupalPath("foo")
+            ->willThrow(new \Exception("Exception", 500));
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->deleteFromDrupalPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 500,
+            "Response must be 500 when Exception occurs"
+        );
+    }
+
+    public function testReturns404WhenNotFound()
+    {
+        $mock_service = $this->prophesize(GeminiService::class)
+            ->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->deleteFromDrupalPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 404,
+            "Response must be 404 when not found"
+        );
+    }
+
+    public function testReturns204WhenDeleted()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $prophecy->deleteFromDrupalPath("foo")
+            ->willReturn(true);
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->deleteFromDrupalPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 204,
+            "Response must be 204 when deleted"
+        );
+    }
+}

--- a/Gemini/tests/Islandora/Gemini/Tests/DeleteFromFedoraPathTest.php
+++ b/Gemini/tests/Islandora/Gemini/Tests/DeleteFromFedoraPathTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Islandora\Gemini\Tests;
+
+use Islandora\Gemini\Controller\GeminiController;
+use Islandora\Gemini\Service\GeminiService;
+
+class DeleteFromFedoraPathTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturns500OnException()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $prophecy->deleteFromFedoraPath("foo")
+            ->willThrow(new \Exception("Exception", 500));
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->deleteFromFedoraPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 500,
+            "Response must be 500 when Exception occurs"
+        );
+    }
+
+    public function testReturns404WhenNotFound()
+    {
+        $mock_service = $this->prophesize(GeminiService::class)
+            ->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->deleteFromFedoraPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 404,
+            "Response must be 404 when not found"
+        );
+    }
+
+    public function testReturns204WhenDeleted()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $prophecy->deleteFromFedoraPath("foo")
+            ->willReturn(true);
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->deleteFromFedoraPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 204,
+            "Response must be 204 when deleted"
+        );
+    }
+}

--- a/Gemini/tests/Islandora/Gemini/Tests/GetDrupalPathTest.php
+++ b/Gemini/tests/Islandora/Gemini/Tests/GetDrupalPathTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Islandora\Gemini\Tests;
+
+use Islandora\Gemini\Controller\GeminiController;
+use Islandora\Gemini\Service\GeminiService;
+
+class GetDrupalPathTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturns500OnException()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $prophecy->getDrupalPath("foo")
+            ->willThrow(new \Exception("Exception", 500));
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->getDrupalPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 500,
+            "Response must be 500 when Exception occurs"
+        );
+    }
+
+    public function testReturns404WhenNotFound()
+    {
+        $mock_service = $this->prophesize(GeminiService::class)
+            ->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->getDrupalPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 404,
+            "Response must be 404 when not found"
+        );
+    }
+
+    public function testReturns200WhenFound()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $prophecy->getDrupalPath("foo")
+            ->willReturn("bar");
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->getDrupalPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 200,
+            "Response must be 200 when found"
+        );
+        $this->assertTrue(
+            $response->getContent() == "bar",
+            "Response must return path when found"
+        );
+    }
+}

--- a/Gemini/tests/Islandora/Gemini/Tests/GetFedoraPathTest.php
+++ b/Gemini/tests/Islandora/Gemini/Tests/GetFedoraPathTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Islandora\Gemini\Tests;
+
+use Islandora\Gemini\Controller\GeminiController;
+use Islandora\Gemini\Service\GeminiService;
+use Symfony\Component\HttpFoundation\Request;
+
+class GetFedoraPathTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturns500OnException()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $prophecy->getFedoraPath("foo")
+            ->willThrow(new \Exception("Exception", 500));
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->getFedoraPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 500,
+            "Response must be 500 when Exception occurs"
+        );
+    }
+
+    public function testReturns404WhenNotFound()
+    {
+        $mock_service = $this->prophesize(GeminiService::class)
+            ->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->getFedoraPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 404,
+            "Response must be 404 when not found"
+        );
+    }
+
+    public function testReturns200WhenFound()
+    {
+        $prophecy = $this->prophesize(GeminiService::class);
+        $prophecy->getFedoraPath("foo")
+            ->willReturn("bar");
+        $mock_service = $prophecy->reveal();
+        $controller = new GeminiController($mock_service);
+
+        $response = $controller->getFedoraPath("foo");
+
+        $this->assertTrue(
+            $response->getStatusCode() == 200,
+            "Response must be 200 when found"
+        );
+        $this->assertTrue(
+            $response->getContent() == "bar",
+            "Response must return path when found"
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "islandora/crayfish",
+    "description": "Collection of Islandora CLAW microservices, lovingly known as Crayfish.",
+    "type": "project",
+    "homepage": "http://islandora.ca/CLAW",
+    "support": {
+        "issues": "https://github.com/islandora-claw/CLAW/issues",
+        "irc": "irc://irc.freenode.net/islandora"
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Islandora Foundation",
+            "email": "community@islandora.ca",
+            "role": "Owner"
+        },
+        {
+            "name": "Jared Whiklo",
+            "email": "jwhiklo@gmail.com",
+            "role": "Maintainer"
+        },
+        {
+            "name": "Nick Ruest",
+            "email": "ruestn@gmail.com",
+            "role": "Maintainer"
+        },
+        {
+            "name": "Diego Pino",
+            "email": "dpino@krayon.cl",
+            "role": "Maintainer"
+        }
+    ]
+}


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/566

Will be smaller after https://github.com/Islandora-CLAW/Crayfish/pull/16 lands, as Hypercube shouldn't be included in the diff then.

# What does this Pull Request do?

Adds a path mapping service to Crayfish.  It's not quite a uri mapping service as per https://github.com/Islandora-CLAW/CLAW/issues/566, it's the part after the base url that gets mapped.  This is to account for Fedora's behaviour with Host headers.

# What's new?
A Silex microservice to align paths between similar objects in Drupal and Fedora.  It will be used extensively by the sync machinery in Alpaca.  It runs off of mysql using Doctrine's database abstraction layer.  See the README for more details.


# How should this be tested?

Try the commands described in the README with cURL or use a client like Postman to test it out.  You can also try running the tests.

# Additional Notes:
I added some for loops in travis with subshell shenanigans.  I doubt those'll work first try.  Don't be suprised if you see Travis updates.

# Interested parties
@Islandora-CLAW/committers