### PR TITLE
Issue 611

### DIFF
--- a/Houdini/src/Controller/HoudiniController.php
+++ b/Houdini/src/Controller/HoudiniController.php
@@ -4,6 +4,7 @@ namespace Islandora\Houdini\Controller;
 
 use GuzzleHttp\Psr7\StreamWrapper;
 use Islandora\Crayfish\Commons\CmdExecuteService;
+use Islandora\Crayfish\Commons\ApixFedoraResourceRetriever;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -64,26 +65,14 @@ class HoudiniController
     }
 
     /**
-     * @param \Psr\Http\Message\ResponseInterface $fedora_resource
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response|\Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function convert(ResponseInterface $fedora_resource, Request $request)
+    public function convert(Request $request)
     {
         $this->log->info('Convert request.');
 
-        $status = $fedora_resource->getStatusCode();
-        if ($status != 200) {
-            $this->log->debug("Fedora Resource: ", [
-              'body' => $fedora_resource->getBody(),
-              'status' => $fedora_resource->getStatusCode(),
-              'headers' => $fedora_resource->getHeaders()
-            ]);
-            return new Response(
-                $fedora_resource->getReasonPhrase(),
-                $status
-            );
-        }
+        $fedora_resource = $request->attributes->get('fedora_resource');
 
         // Get image as a resource.
         $body = StreamWrapper::getResource($fedora_resource->getBody());
@@ -128,26 +117,14 @@ class HoudiniController
     }
 
     /**
-     * @param \Psr\Http\Message\ResponseInterface $fedora_resource
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response|\Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function identify(ResponseInterface $fedora_resource, Request $request)
+    public function identify(Request $request)
     {
         $this->log->info('Identify request.');
 
-        $status = $fedora_resource->getStatusCode();
-        if ($status != 200) {
-            $this->log->debug("Fedora Resource: ", [
-              'body' => $fedora_resource->getBody(),
-              'status' => $fedora_resource->getStatusCode(),
-              'headers' => $fedora_resource->getHeaders()
-            ]);
-            return new Response(
-                $fedora_resource->getReasonPhrase(),
-                $status
-            );
-        }
+        $fedora_resource = $request->attributes->get('fedora_resource');
 
         // Get image as a resource.
         $body = StreamWrapper::getResource($fedora_resource->getBody());

--- a/Houdini/src/app.php
+++ b/Houdini/src/app.php
@@ -6,6 +6,7 @@ use Islandora\Crayfish\Commons\Provider\IslandoraServiceProvider;
 use Islandora\Crayfish\Commons\Provider\YamlConfigServiceProvider;
 use Islandora\Houdini\Controller\HoudiniController;
 use Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
 
 $app = new Application();
 
@@ -22,12 +23,12 @@ $app['houdini.controller'] = function ($app) {
     );
 };
 
-$app->get('/convert/{fedora_resource}', "houdini.controller:convert")
-    ->assert('fedora_resource', '.+')
-    ->convert('fedora_resource', 'crayfish.fedora_resource:convert');
+$app->before(function (Request $request, Application $app) {
+    return $app['crayfish.apix_middleware']->before($request);
+});
 
-$app->get('/identify/{fedora_resource}', "houdini.controller:identify")
-    ->assert('fedora_resource', '.+')
-    ->convert('fedora_resource', 'crayfish.fedora_resource:convert');
+$app->get('/convert', "houdini.controller:convert");
+
+$app->get('/identify', "houdini.controller:identify");
 
 return $app;

--- a/Hypercube/src/Controller/HypercubeController.php
+++ b/Hypercube/src/Controller/HypercubeController.php
@@ -38,19 +38,13 @@ class HypercubeController
     }
 
     /**
-     * @param \Psr\Http\Message\ResponseInterface $fedora_resource
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response|\Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function get(ResponseInterface $fedora_resource, Request $request)
+    public function get(Request $request)
     {
-        $status = $fedora_resource->getStatusCode();
-        if ($status != 200) {
-            return new Response(
-                $fedora_resource->getReasonPhrase(),
-                $status
-            );
-        }
+        // Hack the fedora resource out of the attributes.
+        $fedora_resource = $request->attributes->get('fedora_resource');
 
         // Get tiff as a resource.
         $body = StreamWrapper::getResource($fedora_resource->getBody());

--- a/Hypercube/src/app.php
+++ b/Hypercube/src/app.php
@@ -6,6 +6,7 @@ use Islandora\Crayfish\Commons\Provider\IslandoraServiceProvider;
 use Islandora\Crayfish\Commons\Provider\YamlConfigServiceProvider;
 use Islandora\Hypercube\Controller\HypercubeController;
 use Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
 
 $app = new Application();
 $app->register(new IslandoraServiceProvider());
@@ -18,8 +19,9 @@ $app['hypercube.controller'] = function ($app) {
     );
 };
 
-$app->get('/{fedora_resource}', "hypercube.controller:get")
-    ->assert('fedora_resource', '.+')
-    ->convert('fedora_resource', 'crayfish.fedora_resource:convert');
+$app->get('/', "hypercube.controller:get")
+    ->before(function (Request $request, Application $app) {
+        return $app['crayfish.apix_middleware']->before($request);
+    });
 
 return $app;

--- a/Hypercube/tests/Islandora/Hypercube/Tests/HypercubeControllerTest.php
+++ b/Hypercube/tests/Islandora/Hypercube/Tests/HypercubeControllerTest.php
@@ -9,38 +9,14 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @coversDefaultClass \Islandora\Crayfish\Hypercube\Controller\HypercubeController
+ */
 class HypercubeControllerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testReturnsFedoraError()
-    {
-        // Mock a TesseractService to create a controller.
-        $prophecy = $this->prophesize(CmdExecuteService::class);
-        $mock_service = $prophecy->reveal();
-        $controller = new HypercubeController($mock_service, '');
-
-        // Mock a Fedora response.
-        $prophecy = $this->prophesize(ResponseInterface::class);
-        $prophecy->getStatusCode()->willReturn(401);
-        $prophecy->getReasonPhrase()->willReturn("Unauthorized");
-        $mock_fedora_response = $prophecy->reveal();
-
-        // Create a Request.
-        $request = Request::create(
-            "/foo",
-            "GET"
-        );
-
-        $response = $controller->get($mock_fedora_response, $request);
-        $this->assertTrue(
-            $response->getStatusCode() == 401,
-            "Response code must be Fedora response code"
-        );
-        $this->assertTrue(
-            $response->getContent() == "Unauthorized",
-            "Response must return Fedora's reason phrase"
-        );
-    }
-
+    /**
+     * @covers ::get
+     */
     public function testTesseractErrorReturns500()
     {
         // Mock a TesseractService to create a controller.
@@ -66,23 +42,24 @@ class HypercubeControllerTest extends \PHPUnit_Framework_TestCase
             "/foo",
             "GET"
         );
+        $request->headers->set('Authorization', 'some_token');
+        $request->headers->set('ApixLdpResource', 'http://localhost:8080/fcrepo/rest/foo');
+        $request->attributes->set('fedora_resource', $mock_fedora_response);
 
-        $response = $controller->get($mock_fedora_response, $request);
+        $response = $controller->get($request);
         $this->assertTrue($response->getStatusCode() == 500, "Response must return 500");
         $this->assertTrue($response->getContent() == "ERROR", "Response must return exception's message");
     }
 
+    /**
+     * @covers ::get
+     */
     public function testTesseractSuccessReturns200()
     {
         // Mock a TesseractService to create a controller.
         $prophecy = $this->prophesize(CmdExecuteService::class);
         $mock_service = $prophecy->reveal();
         $controller = new HypercubeController($mock_service, '');
-
-        $request = Request::create(
-            "/foo",
-            "GET"
-        );
 
         // Mock a stream body for a Fedora response.
         $prophecy = $this->prophesize(StreamInterface::class);
@@ -96,7 +73,16 @@ class HypercubeControllerTest extends \PHPUnit_Framework_TestCase
         $prophecy->getBody()->willReturn($mock_stream);
         $mock_fedora_response = $prophecy->reveal();
 
-        $response = $controller->get($mock_fedora_response, $request);
+        // Create a Request.
+        $request = Request::create(
+            "/foo",
+            "GET"
+        );
+        $request->headers->set('Authorization', 'some_token');
+        $request->headers->set('ApixLdpResource', 'http://localhost:8080/fcrepo/rest/foo');
+        $request->attributes->set('fedora_resource', $mock_fedora_response);
+
+        $response = $controller->get($request);
         $this->assertTrue($response->getStatusCode() == 200, "Response must return 200");
     }
 }


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#611

# What does this Pull Request do?

Updates Houdini and Hypercube to use the new ApixMiddleware, which requires the ApixLdpResource header that Api-X is expecting.

# What's new?
Using `before()` middleware instead of converters.  The Fedora response is set as a request attribute wiht the name `fedora_resource`.  Updated tests.

# How should this be tested?

See Islandora-CLAW/CLAW#611 for testing instructions

# Interested parties
@Islandora-CLAW/committers