### PR TITLE
Allows base_uri with path to function

### DIFF
--- a/Milliner/cfg/config.example.yaml
+++ b/Milliner/cfg/config.example.yaml
@@ -1,6 +1,8 @@
 ---
 
 fedora_base_url: http://localhost:8080/fcrepo/rest
+# if drupal_base_url contains a path, be sure to include trailing slash
+# or relative paths will not resolve correctly.
 drupal_base_url: http://localhost:8000
 
 db.options:

--- a/Milliner/composer.json
+++ b/Milliner/composer.json
@@ -31,7 +31,7 @@
         ],
         "test": [
             "@check",
-	    "phpunit --coverage-html 'reports/clover_html' tests/"
+	    "phpunit"
         ]
     },
     "require-dev": {

--- a/Milliner/composer.json
+++ b/Milliner/composer.json
@@ -31,7 +31,7 @@
         ],
         "test": [
             "@check",
-            "phpunit"
+	    "phpunit --coverage-html 'reports/clover_html' tests/"
         ]
     },
     "require-dev": {

--- a/Milliner/src/Converter/DrupalEntityConverter.php
+++ b/Milliner/src/Converter/DrupalEntityConverter.php
@@ -32,7 +32,6 @@ class DrupalEntityConverter
         $this->client = $client;
         $this->log = $log;
     }
-
     /**
      * @param $path
      * @param \Symfony\Component\HttpFoundation\Request $request
@@ -41,8 +40,8 @@ class DrupalEntityConverter
     public function convert($path, Request $request)
     {
         // Return the response from Drupal.
-        $options = $this->preprocess($path, $request);
-        return $this->client->get($path, $options);
+        $options = $this->preprocess($this->clean_path($path), $request);
+        return $this->client->get($this->clean_path($path), $options);
     }
 
     /**
@@ -53,8 +52,8 @@ class DrupalEntityConverter
     public function convertJsonld($path, Request $request)
     {
         // Return the response from Drupal.
-        $options = $this->preprocess($path, $request);
-        return $this->client->get("$path?_format=jsonld", $options);
+        $options = $this->preprocess($this->clean_path($path), $request);
+        return $this->client->get($this->clean_path($path) . '?_format=jsonld', $options);
     }
 
     /**
@@ -78,5 +77,18 @@ class DrupalEntityConverter
 
         // Return guzzle options.
         return $options;
+    }
+
+    /**
+     * @param $path
+     * @return String of path with leading slash removed
+     */
+    private function clean_path($path) {
+        $new_path = $path;
+        // remove leading slash so path is relative to configured 'base_uri' 
+        if (0 === strpos($new_path, '/') ) {
+            $new_path = substr($new_path, 1, strlen($new_path)-1);
+        }
+        return $new_path;
     }
 }

--- a/Milliner/src/Converter/DrupalEntityConverter.php
+++ b/Milliner/src/Converter/DrupalEntityConverter.php
@@ -40,8 +40,8 @@ class DrupalEntityConverter
     public function convert($path, Request $request)
     {
         // Return the response from Drupal.
-        $options = $this->preprocess($this->clean_path($path), $request);
-        return $this->client->get($this->clean_path($path), $options);
+        $options = $this->preprocess($this->cleanPath($path), $request);
+        return $this->client->get($this->cleanPath($path), $options);
     }
 
     /**
@@ -52,8 +52,8 @@ class DrupalEntityConverter
     public function convertJsonld($path, Request $request)
     {
         // Return the response from Drupal.
-        $options = $this->preprocess($this->clean_path($path), $request);
-        return $this->client->get($this->clean_path($path) . '?_format=jsonld', $options);
+        $options = $this->preprocess($this->cleanPath($path), $request);
+        return $this->client->get($this->cleanPath($path) . '?_format=jsonld', $options);
     }
 
     /**
@@ -83,10 +83,11 @@ class DrupalEntityConverter
      * @param $path
      * @return String of path with leading slash removed
      */
-    private function clean_path($path) {
+    private function cleanPath($path) 
+    {
         $new_path = $path;
-        // remove leading slash so path is relative to configured 'base_uri' 
-        if (0 === strpos($new_path, '/') ) {
+        // remove leading slash so path is relative to configured 'base_uri'
+        if (0 === strpos($new_path, '/')) {
             $new_path = substr($new_path, 1, strlen($new_path)-1);
         }
         return $new_path;

--- a/Milliner/src/Converter/DrupalEntityConverter.php
+++ b/Milliner/src/Converter/DrupalEntityConverter.php
@@ -83,7 +83,7 @@ class DrupalEntityConverter
      * @param $path
      * @return String of path with leading slash removed
      */
-    private function cleanPath($path) 
+    private function cleanPath($path)
     {
         $new_path = $path;
         // remove leading slash so path is relative to configured 'base_uri'


### PR DESCRIPTION
This adds the ability to have drupal in a subdirectory (which is my current scenario)
The path that was being passed, via Milliner, to guzzle was absolute, so any path on the base_uri was then lost.

For example, if I my base path was `http://localhost/claw` and the drupal node was `/node/81`, the resulting uri would become `http://localhost/node/81` and not resolve.   This fixes that issue by making sure the leading slash is always removed from the drupal entity string. 

**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

This pull request removes a leading slash from the node path that will be used to talk to drupal with.  This way if the drupal_base_uri has a path on it the node being worked with will still resolve. 

This pull request also adds a note to the config file stating that if you are working with a path on the drupal base uri, make sure you put on a trailing slash, or relative paths will not work. (http://docs.guzzlephp.org/en/stable/quickstart.html)

Full disclosure:  This should not affect drupal base uris with no path on them, they should still resolve just fine, but that is something I haven't tested, given my current setup. 


