### PR TITLE
Issue 828: Refactor schema to allow smaller indexes

### DIFF
--- a/Gemini/bin/console
+++ b/Gemini/bin/console
@@ -1,0 +1,34 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+set_time_limit(0);
+
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+$input = new ArgvInput();
+$env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
+
+$app = require __DIR__.'/../src/app.php';
+$console = require __DIR__.'/../src/console.php';
+
+$app->register(
+    new \Kurl\Silex\Provider\DoctrineMigrationsProvider($console),
+    array(
+        'migrations.directory' => __DIR__ . '/../src/Migrations',
+        'migrations.namespace' => 'Islandora\Gemini\Migrations',
+        'migrations.name' => 'Gemini Migrations',
+        'migrations.table_name' => 'gemini_migrations',
+    )
+);
+
+$console->setHelperSet($app['migrations.em_helper_set']);
+$console->addCommands($app['migrations.commands']);
+
+$console->run();

--- a/Gemini/composer.json
+++ b/Gemini/composer.json
@@ -3,7 +3,9 @@
     "description": "Path mapping Service between Fedora and Drupal",
     "require": {
         "silex/silex": "^2.0",
-        "islandora/crayfish-commons": "dev-master"
+        "islandora/crayfish-commons": "dev-master",
+        "doctrine/migrations": "^1.5",
+        "kurl/silex-doctrine-migrations-provider": "^0.3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/Gemini/composer.lock
+++ b/Gemini/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f5412a4492a1a3927176e38c9648683",
+    "content-hash": "b4440a2119f8e470464b31f52b0190ca",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -477,6 +477,80 @@
             "time": "2014-09-09T13:34:57+00:00"
         },
         {
+            "name": "doctrine/migrations",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/migrations.git",
+                "reference": "c81147c0f2938a6566594455367e095150547f72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/c81147c0f2938a6566594455367e095150547f72",
+                "reference": "c81147c0f2938a6566594455367e095150547f72",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "~2.2",
+                "ocramius/proxy-manager": "^1.0|^2.0",
+                "php": "^5.5|^7.0",
+                "symfony/console": "~2.3|~3.0",
+                "symfony/yaml": "~2.3|~3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "dev-master",
+                "doctrine/orm": "2.*",
+                "jdorn/sql-formatter": "~1.1",
+                "johnkary/phpunit-speedtrap": "~1.0@dev",
+                "mikey179/vfsstream": "^1.6",
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "~4.7",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "suggest": {
+                "jdorn/sql-formatter": "Allows to generate formatted SQL with the diff command."
+            },
+            "bin": [
+                "bin/doctrine-migrations"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "v1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\Migrations\\": "lib/Doctrine/DBAL/Migrations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Michael Simonson",
+                    "email": "contact@mikesimonson.com"
+                }
+            ],
+            "description": "Database Schema migrations using Doctrine DBAL",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "migrations"
+            ],
+            "time": "2016-12-25T22:54:00+00:00"
+        },
+        {
             "name": "easyrdf/easyrdf",
             "version": "0.9.1",
             "source": {
@@ -833,6 +907,46 @@
             "time": "2017-09-21T17:12:48+00:00"
         },
         {
+            "name": "kurl/silex-doctrine-migrations-provider",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kurlltd/silex-doctrine-migrations-provider.git",
+                "reference": "516d515cd1428142635a2c0b34a0e96987c8ac64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kurlltd/silex-doctrine-migrations-provider/zipball/516d515cd1428142635a2c0b34a0e96987c8ac64",
+                "reference": "516d515cd1428142635a2c0b34a0e96987c8ac64",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^2.2",
+                "doctrine/migrations": "^1.5",
+                "php": "^5.6|^7.0",
+                "pimple/pimple": "^3.0",
+                "silex/api": "^2.0",
+                "symfony/console": "^2.3 | ^3.0"
+            },
+            "require-dev": {
+                "doctrine/orm": "^2.2",
+                "phpunit/phpunit": "^5.7",
+                "silex/silex": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Kurl\\Silex\\Provider\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A doctrine migrations provider for silex",
+            "time": "2018-04-06T11:31:28+00:00"
+        },
+        {
             "name": "ml/iri",
             "version": "1.1.4",
             "target-dir": "ML/IRI",
@@ -1068,6 +1182,69 @@
                 "token"
             ],
             "time": "2016-12-05T07:27:31+00:00"
+        },
+        {
+            "name": "ocramius/proxy-manager",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/57e9272ec0e8deccf09421596e0e2252df440e11",
+                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "zendframework/zend-code": ">2.2.5,<3.0"
+            },
+            "require-dev": {
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "1.5.*"
+            },
+            "suggest": {
+                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
+                "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
+                "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
+                "zendframework/zend-stdlib": "To use the hydrator proxy",
+                "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "ProxyManager\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
+            "homepage": "https://github.com/Ocramius/ProxyManager",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "time": "2015-08-09T04:28:19+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -1401,6 +1578,74 @@
                 "microframework"
             ],
             "time": "2017-07-23T07:40:14+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "116bc56e45a8e5572e51eb43ab58c769a352366c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/116bc56e45a8e5572e51eb43ab58c769a352366c",
+                "reference": "116bc56e45a8e5572e51eb43ab58c769a352366c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/debug": "~2.8|~3.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.3",
+                "symfony/dependency-injection": "~3.3",
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/filesystem": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/filesystem": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-10-02T06:42:24+00:00"
         },
         {
             "name": "symfony/debug",
@@ -2218,6 +2463,112 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2017-10-05T14:43:42+00:00"
+        },
+        {
+            "name": "zendframework/zend-code",
+            "version": "2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-code.git",
+                "reference": "95033f061b083e16cdee60530ec260d7d628b887"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/95033f061b083e16cdee60530ec260d7d628b887",
+                "reference": "95033f061b083e16cdee60530ec260d7d628b887",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || 7.0.0 - 7.0.4 || ^7.0.6",
+                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "^4.8.21",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "zendframework/zend-stdlib": "Zend\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev",
+                    "dev-develop": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides facilities to generate arbitrary code using an object oriented interface",
+            "homepage": "https://github.com/zendframework/zend-code",
+            "keywords": [
+                "code",
+                "zf2"
+            ],
+            "time": "2016-04-20T17:26:42+00:00"
+        },
+        {
+            "name": "zendframework/zend-eventmanager",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-eventmanager.git",
+                "reference": "a5e2583a211f73604691586b8406ff7296a946dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/a5e2583a211f73604691586b8406ff7296a946dd",
+                "reference": "a5e2583a211f73604691586b8406ff7296a946dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://github.com/zendframework/zend-eventmanager",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "zf2"
+            ],
+            "time": "2018-04-25T15:33:34+00:00"
         }
     ],
     "packages-dev": [
@@ -3598,74 +3949,6 @@
                 "standards"
             ],
             "time": "2017-05-22T02:43:20+00:00"
-        },
-        {
-            "name": "symfony/console",
-            "version": "v3.3.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "116bc56e45a8e5572e51eb43ab58c769a352366c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/116bc56e45a8e5572e51eb43ab58c769a352366c",
-                "reference": "116bc56e45a8e5572e51eb43ab58c769a352366c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/debug": "~2.8|~3.0",
-                "symfony/polyfill-mbstring": "~1.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<3.3"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~3.3",
-                "symfony/dependency-injection": "~3.3",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/filesystem": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/filesystem": "",
-                "symfony/process": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Console Component",
-            "homepage": "https://symfony.com",
-            "time": "2017-10-02T06:42:24+00:00"
         },
         {
             "name": "symfony/finder",

--- a/Gemini/src/Controller/GeminiController.php
+++ b/Gemini/src/Controller/GeminiController.php
@@ -105,11 +105,11 @@ class GeminiController
         $urls = json_decode($request->getContent(), true);
 
         if (!isset($urls['drupal'])) {
-            return new Response("Missing 'drupal' entry in reqeust body.", 400);
+            return new Response("Missing 'drupal' entry in request body.", 400);
         }
 
         if (!isset($urls['fedora'])) {
-            return new Response("Missing 'fedora' entry in reqeust body.", 400);
+            return new Response("Missing 'fedora' entry in request body.", 400);
         }
 
         // Save URL pair.

--- a/Gemini/src/Migrations/Version20180530031926.php
+++ b/Gemini/src/Migrations/Version20180530031926.php
@@ -22,7 +22,7 @@ final class Version20180530031926 extends AbstractMigration
             'CREATE TABLE Gemini (fedora_hash VARCHAR(128) NOT NULL, 
             drupal_hash VARCHAR(128) NOT NULL, uuid VARCHAR(36) NOT NULL, 
             drupal_uri LONGTEXT NOT NULL, fedora_uri LONGTEXT NOT NULL, 
-            date_created DATETIME NOT NULL, date_updated DATETIME NOT NULL, 
+            dateCreated DATETIME NOT NULL, dateUpdated DATETIME NOT NULL, 
             UNIQUE KEY(fedora_hash, drupal_hash), PRIMARY KEY(uuid)) 
             DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB'
         );

--- a/Gemini/src/Migrations/Version20180530031926.php
+++ b/Gemini/src/Migrations/Version20180530031926.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Islandora\Gemini\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20180530031926 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            $this->connection->getDatabasePlatform()->getName() !== 'mysql',
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql(
+            'CREATE TABLE Gemini (fedora_hash VARCHAR(128) NOT NULL, 
+            drupal_hash VARCHAR(128) NOT NULL, uuid VARCHAR(36) NOT NULL, 
+            drupal_uri LONGTEXT NOT NULL, fedora_uri LONGTEXT NOT NULL, 
+            date_created DATETIME NOT NULL, date_updated DATETIME NOT NULL, 
+            UNIQUE KEY(fedora_hash, drupal_hash), PRIMARY KEY(uuid)) 
+            DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB'
+        );
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            $this->connection->getDatabasePlatform()->getName() !== 'mysql',
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+        $this->addSql('DROP TABLE Gemini');
+    }
+}

--- a/Gemini/src/UrlMapper/UrlMapper.php
+++ b/Gemini/src/UrlMapper/UrlMapper.php
@@ -53,8 +53,8 @@ class UrlMapper implements UrlMapperInterface
         $now = time();
         $db_data = [
           'uuid' => $uuid,
-          'drupal_uri' => $drupal,
-          'fedora_uri' => $fedora,
+          'drupal_uri' => $drupal_uri,
+          'fedora_uri' => $fedora_uri,
           'drupal_hash' => $drupal_hash,
           'fedora_hash' => $fedora_hash,
           'dateCreated' => $now,

--- a/Gemini/src/UrlMapper/UrlMapper.php
+++ b/Gemini/src/UrlMapper/UrlMapper.php
@@ -50,7 +50,7 @@ class UrlMapper implements UrlMapperInterface
         // Hash incomming URIs
         $fedora_hash = hash('sha512', $fedora_uri);
         $drupal_hash = hash('sha512', $drupal_uri);
-        $now = time();
+        $now = date("Y-m-d H:i:s",time());
         $db_data = [
           'uuid' => $uuid,
           'drupal_uri' => $drupal_uri,

--- a/Gemini/src/console.php
+++ b/Gemini/src/console.php
@@ -1,0 +1,14 @@
+<?php
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+$console = new \Symfony\Component\Console\Application('Gemini Console', 'n/a');
+$console->getDefinition()
+  ->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'));
+$console->setDispatcher($app['dispatcher']);
+
+return $console;


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora-CLAW/CLAW/issues/828)

# What does this Pull Request do?

Refactors Gemini (Fedora/Drupal URI Mapper) to use hash based primary keys (composite) in its DB.
This is still Silex until we move to Symfony.
I also added a Symfony/Console app. using Doctrine's Migrate model to allow Table creation (and keeping track of changes) using console app

# What's new?
New DB table schema includes 4 new fields, fedora_hash, drupal_hash, dateCreated and dateUpdated


* Does this change require documentation to be updated? No, all the public part was left as-IS
* Does this change add any new dependencies? yep, run composer install (or update if you are unsure about your PHP version)
* Does this change require any other modifications to be made to the repository 
Totally. Since Gemini is a deal breaker/repo-cms superglue, you need to move your already existing mapped values to this new schema or drop and start from scratch. Manual procedure is quite simple. Just update your schema, then add hashes (sha512) and timestamps (now() is good enough) to existing values
* Could this change impact execution of existing code? No

# How should this be tested?

Pull or apply patch
run `composer install` inside Gemini
Make sure your working and existing config.yaml file is still there and it works
run ```php bin/console list``` to see available commands
run ```php bin/console migrations:migrate``` which will trigger a Migration file. (fancy name for MYSQL SQL!)

Migration file was written for MYSQL 5.7, will work on 5.6 too. But if other DBs are used, a new migration schema will have to be generated

# Additional Notes:

This was made in a hurry today since I did most of the fun stuff on Symfony4! and is mostly a backport to keep the ball rolling. Backport means i could have forgotten something, please test and give me all the feedback and concern, change requests you want.

If this goes in I will make the ansible pull too, which is really just running ```php bin/console migrations:migrate```which by the way could be automatized to run when composer install runs via composer.json file.


# Interested parties
Tag (@seth-shaw-unlv @ajs6f @DigitLib @dannylamb  @Islandora-CLAW/committers)