### PR TITLE
add postgresql migration

### DIFF
--- a/Gemini/src/Migrations/Version20180530031926.php
+++ b/Gemini/src/Migrations/Version20180530031926.php
@@ -12,20 +12,37 @@ final class Version20180530031926 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
-        // this up() migration is auto-generated, please modify it to your needs
-        $this->abortIf(
-            $this->connection->getDatabasePlatform()->getName() !== 'mysql',
-            'Migration can only be executed safely on \'mysql\'.'
-        );
+      $this->addSql(
+        'DROP TABLE IF EXISTS Gemini;'
+      );
 
+      if  ('mysql' == $this->connection->getDatabasePlatform()->getName())  {
         $this->addSql(
-            'CREATE TABLE Gemini (fedora_hash VARCHAR(128) NOT NULL, 
-            drupal_hash VARCHAR(128) NOT NULL, uuid VARCHAR(36) NOT NULL, 
-            drupal_uri LONGTEXT NOT NULL, fedora_uri LONGTEXT NOT NULL, 
-            dateCreated DATETIME NOT NULL, dateUpdated DATETIME NOT NULL, 
-            UNIQUE KEY(fedora_hash, drupal_hash), PRIMARY KEY(uuid)) 
-            DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB'
+          'CREATE TABLE Gemini (fedora_hash VARCHAR(128) NOT NULL,
+          drupal_hash VARCHAR(128) NOT NULL, uuid VARCHAR(36) NOT NULL,
+          drupal_uri LONGTEXT NOT NULL, fedora_uri LONGTEXT NOT NULL,
+          dateCreated DATETIME NOT NULL, dateUpdated DATETIME NOT NULL,
+          UNIQUE KEY(fedora_hash, drupal_hash), PRIMARY KEY(uuid))
+          DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB'
         );
+      }
+      elseif
+      ('postgresql' == $this->connection->getDatabasePlatform()->getName())  {
+        $this->addSql(
+          'CREATE TABLE Gemini (
+             fedora_hash VARCHAR(128) NOT NULL,
+             drupal_hash VARCHAR(128) NOT NULL,
+             uuid VARCHAR(36) PRIMARY KEY,
+             drupal_uri TEXT NOT NULL,
+             fedora_uri TEXT NOT NULL,
+             dateCreated TIMESTAMP NOT NULL,
+             dateUpdated TIMESTAMP NOT NULL
+           );'
+        );
+        $this->addSql(
+          'CREATE UNIQUE INDEX fedora_drupal_hash ON Gemini (fedora_hash, drupal_hash);'
+        );
+      }
     }
 
     public function down(Schema $schema)

--- a/Gemini/src/Migrations/Version20180530031926.php
+++ b/Gemini/src/Migrations/Version20180530031926.php
@@ -43,6 +43,9 @@ final class Version20180530031926 extends AbstractMigration
           'CREATE UNIQUE INDEX fedora_drupal_hash ON Gemini (fedora_hash, drupal_hash);'
         );
       }
+      else {
+        $this->abortIf(TRUE, "Only MySQL/MariaDB and PostgreSQL are supported.");
+      }
     }
 
     public function down(Schema $schema)


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#722

Follow up to Islandora-CLAW/Crayfish/pull/46

# What does this Pull Request do?

Adds a postgres support for the Gemini migration.

# What's new?

Compares the installed db and issues the appropriate SQL command. Note that it now drops any existing Gemini db, so back it up before you use this. 

# How should this be tested?

Same as Islandora-CLAW/Crayfish/pull/46 except with postgres!

- Pull or apply patch
- run composer install inside Gemini
- Make sure your working and existing config.yaml file is still there and it works
- run `php bin/console list` to see available commands
- run `php bin/console migrations:migrate` which will trigger a Migration file.

# Interested parties

@DiegoPino  @Islandora-CLAW/committers 