### PR TITLE
support audio formats

### DIFF
--- a/Homarus/cfg/config.example.yaml
+++ b/Homarus/cfg/config.example.yaml
@@ -7,12 +7,18 @@ homarus:
       - video/mp4
       - video/x-msvideo
       - video/ogg
+      - audio/x-wav
+      - audio/mpeg
+      - audio/aac
     default: video/mp4
   mime_to_format:
     valid:
       - video/mp4_mp4
       - video/x-msvideo_avi
       - video/ogg_ogg
+      - audio/x-wav_wav
+      - audio/mpeg_mp3
+      - audio/aac_m4a
     default: mp4
 
 fedora_resource:

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -125,7 +125,7 @@ class HomarusController
         $args = $request->headers->get('X-Islandora-Args');
         $this->log->debug("X-Islandora-Args:", ['args' => $args]);
 
-        $cmd_string = "$this->executable -i $source $cmd_params -f $format -";
+        $cmd_string = "$this->executable -i $source $args $cmd_params -f $format -";
         $this->log->debug('Ffempg Command:', ['cmd' => $cmd_string]);
 
         // Return response.


### PR DESCRIPTION
**GitHub Issue**: (link)
* https://github.com/Islandora-CLAW/CLAW/issues/930

# What does this Pull Request do?
This PR adds configuration to enable creation of audio derivative files using Homarus/ffmpeg.  

# How should this be tested?
* claw-playbook `vagrant up` with this PR: https://github.com/Islandora-Devops/ansible-role-crayfish/pull/18

The easiest way to test this component alone would be to replace the following with the ones in the PR.  
* Homarus/src/Controller/HomarusController.php

Create an audio file in Fedora.  Then issue the following curl command:
```
curl -H "Authorization: Bearer islandora" -H "Accept: audio/mpeg" -H "X-Islandora-Args: -codec:a libmp3lame -q:a 5" -H "Apix-Ldp-Resource:http://localhost:8080/fcrepo/rest/2019-02/input3.wav" http://localhost:8000/homarus/convert --output output.mp3
```

# Interested parties

@dannylamb 
@MarcusBarnes 
@Islandora-CLAW/committers