### PR TITLE
Use describes URI if it exists

### DIFF
--- a/Recast/src/Controller/RecastController.php
+++ b/Recast/src/Controller/RecastController.php
@@ -88,6 +88,14 @@ class RecastController
 
         $fedora_uri = $request->headers->get("Apix-Ldp-Resource");
         $fedora_resource = $request->attributes->get('fedora_resource');
+
+        // Look for a describes Link header.
+        $describe_uri = $fedora_resource->hasHeader('Link') ? self::describeUri($fedora_resource->getheader('Link')) : FALSE;
+        if ($describe_uri !== FALSE) {
+          // We found a describes URI so use that for the subject of the graph.
+          $fedora_uri = $describe_uri;
+        }
+
         $body = (string) $fedora_resource->getBody();
         $mimeType = $fedora_resource->getHeader('Content-type');
         if (is_array($mimeType)) {
@@ -225,5 +233,43 @@ class RecastController
             return $p;
         }
         return null;
+    }
+
+  /**
+   * Return any found describes link headers or FALSE.
+   *
+   * @param array $link_header
+   *   The array of Link headers.
+   * @return false|string
+   *   The URI described or false if not found.
+   */
+    private static function describeUri(array $link_header) {
+      array_walk($link_header, ['self', 'parseLinkHeaders']);
+      $match = array_search('describes', array_column($link_header, 'rel'));
+      if (is_int($match)) {
+        $match = $link_header[$match]['uri'];
+      }
+      return $match;
+    }
+
+  /**
+   * Parse an array of string link headers in to associative arrays.
+   *
+   * Format is [
+   *   'uri' => 'the uri',
+   *   'rel' => 'the rel parameter',
+   * ]
+   *
+   * @param $o
+   *   The input array of link headers.
+   */
+    private static function parseLinkHeaders(&$o) {
+      $part = trim($o);
+      if (preg_match("/<([^>]+)>;\s*rel=\"?(\w+)\"?/", $part, $match)) {
+        $o = [
+          'uri' => $match[1],
+          'rel' => $match[2],
+        ];
+      }
     }
 }

--- a/Recast/src/Controller/RecastController.php
+++ b/Recast/src/Controller/RecastController.php
@@ -90,10 +90,11 @@ class RecastController
         $fedora_resource = $request->attributes->get('fedora_resource');
 
         // Look for a describes Link header.
-        $describe_uri = $fedora_resource->hasHeader('Link') ? self::describeUri($fedora_resource->getheader('Link')) : FALSE;
-        if ($describe_uri !== FALSE) {
-          // We found a describes URI so use that for the subject of the graph.
-          $fedora_uri = $describe_uri;
+        $describe_uri = $fedora_resource->hasHeader('Link') ? self::describeUri($fedora_resource->getheader('Link'))
+          : false;
+        if ($describe_uri !== false) {
+            // We found a describes URI so use that for the subject of the graph.
+            $fedora_uri = $describe_uri;
         }
 
         $body = (string) $fedora_resource->getBody();
@@ -243,13 +244,14 @@ class RecastController
    * @return false|string
    *   The URI described or false if not found.
    */
-    private static function describeUri(array $link_header) {
-      array_walk($link_header, ['self', 'parseLinkHeaders']);
-      $match = array_search('describes', array_column($link_header, 'rel'));
-      if (is_int($match)) {
-        $match = $link_header[$match]['uri'];
-      }
-      return $match;
+    private static function describeUri(array $link_header)
+    {
+        array_walk($link_header, ['self', 'parseLinkHeaders']);
+        $match = array_search('describes', array_column($link_header, 'rel'));
+        if (is_int($match)) {
+            $match = $link_header[$match]['uri'];
+        }
+        return $match;
     }
 
   /**
@@ -263,13 +265,14 @@ class RecastController
    * @param $o
    *   The input array of link headers.
    */
-    private static function parseLinkHeaders(&$o) {
-      $part = trim($o);
-      if (preg_match("/<([^>]+)>;\s*rel=\"?(\w+)\"?/", $part, $match)) {
-        $o = [
-          'uri' => $match[1],
-          'rel' => $match[2],
-        ];
-      }
+    private static function parseLinkHeaders(&$o)
+    {
+        $part = trim($o);
+        if (preg_match("/<([^>]+)>;\s*rel=\"?(\w+)\"?/", $part, $match)) {
+            $o = [
+                'uri' => $match[1],
+                'rel' => $match[2],
+            ];
+        }
     }
 }

--- a/Recast/tests/RecastControllerTests.php
+++ b/Recast/tests/RecastControllerTests.php
@@ -215,6 +215,8 @@ class RecastControllerTest extends TestCase
         $prophecy->getStatusCode()->willReturn(200);
         $prophecy->getBody()->willReturn($mock_stream);
         $prophecy->getHeader('Content-type')->willReturn($content_type);
+        // This is to avoid the describes check, should add a test for it.
+        $prophecy->hasHeader('Link')->willReturn(false);
         $mock_fedora_response = $prophecy->reveal();
         return $mock_fedora_response;
     }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1114 & https://github.com/Islandora-CLAW/CLAW/issues/1115


# What does this Pull Request do?

In Recast:

When parsing graphs of NonRDFSource descriptions we need to get the correct URI to parse it. This PR checks for a `Link: <http://localhost:8080/fcrepo/rest/binary>; rel="describes"` header and returns the URI so the graph is correct.

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Use Recast and see the examples in the above tickets, pull in this PR and see that the graph has the correct subject.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

# Interested parties
@Islandora-CLAW/committers and @elizoller