### PR TITLE
 Stripping _format=jsonld when configured to do so

### DIFF
--- a/Milliner/cfg/config.example.yaml
+++ b/Milliner/cfg/config.example.yaml
@@ -5,7 +5,10 @@ fedora_base_url: http://localhost:8080/fcrepo/rest
 # or relative paths will not resolve correctly.
 drupal_base_url: http://localhost:8000
 gemini_base_url: http://localhost:8000/gemini
+
 modified_date_predicate: http://schema.org/dateModified
+
+strip_format_jsonld: true 
 
 debug: false
 

--- a/Milliner/src/Service/MillinerService.php
+++ b/Milliner/src/Service/MillinerService.php
@@ -42,7 +42,7 @@ class MillinerService implements MillinerServiceInterface
     /**
      * @var string
      */
-    protected $stripUnderscoreJsonld;
+    protected $stripFormatJsonld;
 
     /**
      * MillinerService constructor.
@@ -52,7 +52,7 @@ class MillinerService implements MillinerServiceInterface
      * @param \Islandora\Crayfish\Commons\Client\GeminiClient
      * @param \Psr\Log\LoggerInterface $log
      * @param string $modifiedDatePredicate
-     * @param string $stripUnderscoreJsonld
+     * @param string $stripFormatJsonld
      */
     public function __construct(
         IFedoraApi $fedora,
@@ -60,14 +60,14 @@ class MillinerService implements MillinerServiceInterface
         GeminiClient $gemini,
         LoggerInterface $log,
         $modifiedDatePredicate,
-        $stripUnderscoreJsonld
+        $stripFormatJsonld
     ) {
         $this->fedora = $fedora;
         $this->drupal = $drupal;
         $this->gemini = $gemini;
         $this->log = $log;
         $this->modifiedDatePredicate = $modifiedDatePredicate;
-        $this->stripUnderscoreJsonld = $stripUnderscoreJsonld;
+        $this->stripFormatJsonld = $stripFormatJsonld;
     }
 
     /**
@@ -131,7 +131,7 @@ class MillinerService implements MillinerServiceInterface
             true
         );
 
-        $subject_url = $this->stripUnderscoreJsonld ? $entity_url : $jsonld_url;
+        $subject_url = $this->stripFormatJsonld ? $entity_url : $jsonld_url;
 
         // Mash it into the shape Fedora accepts.
         $jsonld = $this->processJsonld(
@@ -240,7 +240,7 @@ class MillinerService implements MillinerServiceInterface
         );
 
         // Mash it into the shape Fedora accepts.
-        $subject_url = $this->stripUnderscoreJsonld ? $entity_url : $jsonld_url;
+        $subject_url = $this->stripFormatJsonld ? $entity_url : $jsonld_url;
         $drupal_jsonld = $this->processJsonld(
             $drupal_jsonld,
             $subject_url,

--- a/Milliner/src/Service/MillinerService.php
+++ b/Milliner/src/Service/MillinerService.php
@@ -125,7 +125,7 @@ class MillinerService implements MillinerServiceInterface
             $jsonld_url,
             ['headers' => $headers]
         );
-        $this->log->debug("BEFORE:", ['jsonld' => $drupal_response->getBody()]);
+
         $jsonld = json_decode(
             $drupal_response->getBody(),
             true
@@ -140,7 +140,6 @@ class MillinerService implements MillinerServiceInterface
             $fedora_url
         );
 
-        $this->log->debug("AFTER:", ['jsonld' => json_encode($jsonld)]);
         // Save it in Fedora.
         $headers['Content-Type'] = 'application/ld+json';
         $headers['Prefer'] = 'return=minimal; handling=lenient';

--- a/Milliner/src/app.php
+++ b/Milliner/src/app.php
@@ -21,12 +21,12 @@ $app['debug'] = $app['crayfish.debug'];
 
 $app['milliner.controller'] = function () use ($app) {
     try {
-        $strip_underscore_format_jsonld = filter_var(
-            $app['crayfish.strip_underscore_format_jsonld'],
+        $strip_format_jsonld = filter_var(
+            $app['crayfish.strip_format_jsonld'],
             FILTER_VALIDATE_BOOLEAN
         );
     } catch (UnknownIdentifierException $e) {
-        $strip_underscore_format_jsonld = false;
+        $strip_format_jsonld = false;
     }
 
     return new MillinerController(
@@ -39,7 +39,7 @@ $app['milliner.controller'] = function () use ($app) {
             ),
             $app['monolog'],
             $app['crayfish.modified_date_predicate'],
-            $strip_underscore_format_jsonld
+            $strip_format_jsonld
         ),
         $app['monolog']
     );

--- a/Milliner/tests/Islandora/Milliner/Tests/DeleteTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/DeleteTest.php
@@ -67,7 +67,8 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->deleteNode("abc123", "Bearer islandora");
@@ -100,7 +101,8 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $response = $milliner->deleteNode("first", "Bearer islandora");
@@ -140,7 +142,8 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $response = $milliner->deleteNode("abc123", "Bearer islandora");
@@ -176,7 +179,8 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $response = $milliner->deleteNode("abc123", "Bearer islandora");

--- a/Milliner/tests/Islandora/Milliner/Tests/SaveExternalTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/SaveExternalTest.php
@@ -74,7 +74,8 @@ class SaveExternalTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveExternal(
@@ -117,7 +118,8 @@ class SaveExternalTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveExternal(
@@ -156,7 +158,8 @@ class SaveExternalTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveExternal(
@@ -203,7 +206,8 @@ class SaveExternalTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveExternal(

--- a/Milliner/tests/Islandora/Milliner/Tests/SaveMediaTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/SaveMediaTest.php
@@ -72,7 +72,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveMedia(
@@ -113,7 +114,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveMedia(
@@ -157,7 +159,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveMedia(
@@ -210,7 +213,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveMedia(
@@ -263,7 +267,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveMedia(
@@ -326,7 +331,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveMedia(
@@ -401,7 +407,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveMedia(
@@ -481,7 +488,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveMedia(
@@ -559,7 +567,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $response = $milliner->saveMedia(
@@ -644,7 +653,8 @@ class SaveMediaTest extends \PHPUnit_Framework_TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $response = $milliner->saveMedia(

--- a/Milliner/tests/Islandora/Milliner/Tests/SaveNodeTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/SaveNodeTest.php
@@ -76,7 +76,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveNode(
@@ -124,7 +125,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveNode(
@@ -180,7 +182,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveNode(
@@ -229,7 +232,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $response = $milliner->saveNode(
@@ -284,7 +288,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $response = $milliner->saveNode(
@@ -334,7 +339,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveNode(
@@ -390,7 +396,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            "total garbage"
+            "total garbage",
+            false
         );
 
         $milliner->saveNode(
@@ -446,7 +453,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveNode(
@@ -505,7 +513,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $milliner->saveNode(
@@ -564,7 +573,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $response = $milliner->saveNode(
@@ -629,7 +639,8 @@ class SaveNodeTest extends TestCase
             $drupal,
             $gemini,
             $this->logger,
-            $this->modifiedDatePredicate
+            $this->modifiedDatePredicate,
+            false
         );
 
         $response = $milliner->saveNode(


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/887

Goes with:
- https://github.com/Islandora-CLAW/jsonld/pull/32
- https://github.com/Islandora-CLAW/islandora/pull/133

Supersedes:
- https://github.com/Islandora-CLAW/Crayfish/pull/65

# What does this Pull Request do?

**This is the same as https://github.com/Islandora-CLAW/Crayfish/pull/65, but on the Foundation's fork so we can test with the installer.**

Allows you to set a `strip_format_jsonld` configuration variable (false by default).  If set to true, `?_format=jsonld` will get stripped off before searching the jsonld when processing it.  This configuration should always be in alignment with the configuration in the `jsonld` module from https://github.com/Islandora-CLAW/jsonld/pull/32.  If it is out of alignment, when Milliner prepares the jsonld to go to Fedora, it will not be able to find the right url, and will end up stripping out all the RDF by accident.

# What's new?
A new confguration, `strip_format_jsonld`, to mirror the `jsonld` module's configuration.

# How should this be tested?

https://github.com/Islandora-CLAW/CLAW/issues/887

# Interested parties
@Islandora-CLAW/committers