### PR TITLE
Using file url for media

### DIFF
--- a/Milliner/src/Service/MillinerService.php
+++ b/Milliner/src/Service/MillinerService.php
@@ -430,7 +430,7 @@ class MillinerService implements MillinerServiceInterface
         }
 
         return $this->updateNode(
-            rtrim($jsonld_url, '?_format=jsonld'),
+            $urls['drupal'],
             $jsonld_url,
             $fedora_url,
             $token


### PR DESCRIPTION
**GitHub Issue**: Part of Islandora-CLAW/CLAW#662

Goes with https://github.com/Islandora-CLAW/islandora/pull/136 and https://github.com/Islandora-CLAW/islandora_demo/pull/29

# What does this Pull Request do?

Passes in the Drupal url from Gemini instead of trying to reconstruct it (which was brittle and failing) when saving RDF.  This way, nodes and media work the same, despite having very different subject urls.

# How should this be tested?
See https://github.com/Islandora-CLAW/islandora/pull/136

# Interested parties
@whikloj @Islandora-CLAW/committers