### PR TITLE
De-CLAWing readme files

### DIFF
--- a/Gemini/README.md
+++ b/Gemini/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-A path mapping service for Islandora-CLAW.  Gemini is what links content created in Drupal to data stored in Fedora.  It has a very simple API and is built on top of a relational database using Doctrine's [database abstraction layer][4].
+A path mapping service for Islandora 8.  Gemini is what links content created in Drupal to data stored in Fedora.  It has a very simple API and is built on top of a relational database using Doctrine's [database abstraction layer][4].
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE)
 [![codecov](https://codecov.io/gh/Islandora-CLAW/Crayfish/branch/master/graph/badge.svg)](https://codecov.io/gh/Islandora-CLAW/Crayfish)
 
-A collection of Islandora CLAW microservices, lovingly known as Crayfish.  Some of the microservices are built specifically for use with a Fedora Repository and API-X, while others are just for general use within CLAW.
+A collection of Islandora 8 microservices, lovingly known as Crayfish.  Some of the microservices are built specifically for use with a Fedora Repository and API-X, while others are just for general use within Islandora 8.
 
 ## Requirements
 
@@ -29,7 +29,7 @@ See the individual services for more information on their endpoints.
 
 ## Security
 
-Crayfish microservices use JWTs to handle authentication like the rest of the Islandora CLAW.
+Crayfish microservices use JWTs to handle authentication like the rest of the Islandora 8.
 It is disabled by default. To enable, set `security enabled` to `true` in `cfg/cfg.php` for any microservice.
 You can also set the path to an xml configuration file for security a la [Syn][9] with the `security config` parameter.
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1082

# What does this Pull Request do?

Replaces references to Islandora CLAW in readme files with "Islandora 8." Does not go any deeper into the code to hunt down CLAWs.

# What's new?

Islandora CLAW -> Islandora 8 in Crayfish readmes.

# How should this be tested?

Review and make sure I got'em all. 

# Additional Notes:

I know there's a lot more work to be done here with the branding and how deep "CLAW" has gotten into the stack, but this seems like low-hanging fruit that we might as well get out of the way so our public face is more consistent. 

First PR of many.

# Interested parties
@Islandora-CLAW/committers