### PR TITLE
Adding pdftotext for PDF support in Hypercube

### DIFF
--- a/Hypercube/cfg/config.example.yaml
+++ b/Hypercube/cfg/config.example.yaml
@@ -2,7 +2,8 @@
 
 hypercube:
   # path to the convert executable
-  executable: tesseract
+  tesseract_executable: tesseract
+  pdftotext_executable: pdftotext
 
 fedora_resource:
   base_url: http://localhost:8080/fcrepo/rest

--- a/Hypercube/src/Controller/HypercubeController.php
+++ b/Hypercube/src/Controller/HypercubeController.php
@@ -72,19 +72,18 @@ class HypercubeController
         // Arguments to command line are sent as a custom header
         $args = $request->headers->get('X-Islandora-Args');
 
-	// Check content type and use the appropriate command line tool.
-	$content_type = $fedora_resource->getHeader('Content-Type')[0];
-	
-	$this->log->debug("Got Content-Type:", ['type' => $content_type]);
+        // Check content type and use the appropriate command line tool.
+        $content_type = $fedora_resource->getHeader('Content-Type')[0];
+    
+        $this->log->debug("Got Content-Type:", ['type' => $content_type]);
 
-	if ($content_type == 'application/pdf') {
+        if ($content_type == 'application/pdf') {
             $cmd_string = $this->pdftotext_executable . " $args - -";
-        }
-        else {
+        } else {
             $cmd_string = $this->tesseract_executable . " stdin stdout $args";
         }
 
-	$this->log->debug("Executing command:", ['cmd' => $cmd_string]);
+        $this->log->debug("Executing command:", ['cmd' => $cmd_string]);
 
         // Return response.
         try {

--- a/Hypercube/src/app.php
+++ b/Hypercube/src/app.php
@@ -15,7 +15,9 @@ $app->register(new YamlConfigServiceProvider(__DIR__ . '/../cfg/config.yaml'));
 $app['hypercube.controller'] = function ($app) {
     return new HypercubeController(
         $app['crayfish.cmd_execute_service'],
-        $app['crayfish.hypercube.executable']
+        $app['crayfish.hypercube.tesseract_executable'],
+        $app['crayfish.hypercube.pdftotext_executable'],
+        $app['monolog']
     );
 };
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/933

# What does this Pull Request do?

Adds pdftotext support for Hypercube.

# What's new?
Hypercube now checks the content type of the resource and uses pdftotext if it receives a PDF.

# How should this be tested?

- `sudo apt-get install pdftotext`
- Pull this down into crayfish
- Update the `executable` entry in `config.yaml` to be `tesseract_executable` and `pdftotext_executable` as per `config.example.yaml`.
- Upload a PDF
- Hit hypercube with something like this: `curl -H "Authorization: Bearer islandora" -H "Apix-Ldp-Resource: http://localhost:8080/fcrepo/rest/2019-09/my-file.pdf" localhost:8000/hypercube/`
- Watch the lovely extracted text get blurted out onto your console.

# Additional Notes:
Updated ansible role coming soon.

# Interested parties
@Islandora-CLAW/committers