### PR TITLE
Default pdftotext to UTF-8: Issue 1582

### DIFF
--- a/Hypercube/src/Controller/HypercubeController.php
+++ b/Hypercube/src/Controller/HypercubeController.php
@@ -78,7 +78,7 @@ class HypercubeController
         $this->log->debug("Got Content-Type:", ['type' => $content_type]);
 
         if ($content_type == 'application/pdf') {
-            $cmd_string = $this->pdftotext_executable . " $args - -";
+            $cmd_string = $this->pdftotext_executable . " $args -enc UTF-8 - -";
         } else {
             $cmd_string = $this->tesseract_executable . " stdin stdout $args";
         }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1582

# What does this Pull Request do?

Changes the default output of pdftotext form Latin-1 to UTF-8.

# What's new?

* Added `-enc UTF-8` as a parameter to pdftotext.

# How should this be tested?

* Take an existing Islandora 8 site and add a Digital Document node/media with a PDF original file including non-latin characters. I used [https://fsi-languages.yojik.eu/languages/PeaceCorps/Arabic-Moroccan/MO_Arabic_Language_Lessons.pdf](https://fsi-languages.yojik.eu/languages/PeaceCorps/Arabic-Moroccan/MO_Arabic_Language_Lessons.pdf) for my test case.
* Ensure the text was extracted by looking at the node's extracted text media. You won't see any of the non-latin characters.
* Apply the PR
* Run the Extract Text action on the Digital Document node again to extract the text again.
* Look at the extracted text media again and you should now see non-latin characters in your output.

# Interested parties
@Islandora/8-x-committers
