### PR TITLE
Configurable domain

### DIFF
--- a/Gemini/cfg/config.example.yaml
+++ b/Gemini/cfg/config.example.yaml
@@ -2,7 +2,11 @@
 
 debug: false 
 
-fedora_base_url: http://localhost:8080/fcrepo/rest
+# Leave these blank unless you know what you're doing.  If you're moving
+# data from one server to another and the domain changes, set these
+# to your new domain.
+fedora_domain: 
+drupal_domain: 
 
 db.options:
   driver: pdo_mysql

--- a/Gemini/src/Controller/GeminiController.php
+++ b/Gemini/src/Controller/GeminiController.php
@@ -33,9 +33,9 @@ class GeminiController
 
     /**
      * GeminiController constructor.
-     * @param \Islandora\Gemini\UrlMapper\UrlMapperInterface
-     * @param \Islandora\Gemini\UrlMinter\UrlMinterInterface
-     * @param \Symfony\Component\Routing\Generator\UrlGenerator
+     * @param \Islandora\Gemini\UrlMapper\UrlMapperInterface $urlMapper
+     * @param \Islandora\Gemini\UrlMinter\UrlMinterInterface $urlMinter
+     * @param \Symfony\Component\Routing\Generator\UrlGenerator $urlGenerator
      */
     public function __construct(
         UrlMapperInterface $urlMapper,

--- a/Gemini/src/UrlMapper/UrlMapper.php
+++ b/Gemini/src/UrlMapper/UrlMapper.php
@@ -54,11 +54,11 @@ class UrlMapper implements UrlMapperInterface
             ['uuid' => $uuid]
         );
 
-        if (!empty($this->drupalDomain)) {
+        if (!empty($this->drupalDomain) && isset($result['drupal'])) {
             $result['drupal'] = $this->replaceDomain($result['drupal'], $this->drupalDomain);
         }
 
-        if (!empty($this->fedoraDomain)) {
+        if (!empty($this->fedoraDomain) && isset($result['fedora'])) {
             $result['fedora'] = $this->replaceDomain($result['fedora'], $this->fedoraDomain);
         }
 

--- a/Gemini/src/app.php
+++ b/Gemini/src/app.php
@@ -15,7 +15,11 @@ $app->register(new IslandoraServiceProvider());
 $app->register(new YamlConfigServiceProvider(__DIR__ . '/../cfg/config.yaml'));
 $app['debug'] = $app['crayfish.debug'];
 $app['gemini.mapper'] = function ($app) {
-    return new UrlMapper($app['db']);
+    return new UrlMapper(
+        $app['db'],
+        $app['crayfish.drupal_domain'],
+        $app['crayfish.fedora_domain']
+    );
 };
 $app['gemini.minter'] = function ($app) {
     return new UrlMinter();


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1664

# What does this Pull Request do?

These changes let you configure Gemini with drupal and fedora domains.  If you do not configure these values, behaviour is unchanged.

This is useful when you want to take data ingested in one environment to another, like a testing/staging server to production.  By configuring the `drupal_domain` and `fedora_domain` variables, you can force gemini to rewrite the urls on the way out so that they have the new domain.

# What's new?
Jams in two new config variables and makes `getUrls()` and `findByUri()` respect them.

# How should this be tested?

- Pull these changes in
- Copy/paste this chunk from `config.example.yml` to your `config.yaml` file
```
# Leave these blank unless you know what you're doing.  If you're moving
# data from one server to another and the domain changes, set these
# to your new domain.
fedora_domain:
drupal_domain:
```
- test gemini and confirm behaviour is the same.  i queried for a uuid, and then queried for the same item using `by_uri`
```
$ curl -s -H "Authorization: Bearer islandora" http://localhost:8000/gemini/02862b7c-0a80-45af-bc2a-690a007e40a0 | jq
{
  "drupal": "http://localhost:18000/_flysystem/fedora/islandora_3_TECHMD.xml",
  "fedora": "http://127.0.0.1:8080/fcrepo/rest/islandora_3_TECHMD.xml"
}

$ curl -I -H "X-Islandora-URI: http://localhost:18000/_flysystem/fedora/islandora_3_TECHMD.xml" -H "Authorization: Bearer islandora" http://localhost:8000/gemini/by_uri
HTTP/1.1 200 OK
Date: Mon, 09 Nov 2020 19:32:02 GMT
Server: Apache/2.4.29 (Ubuntu)
X-Powered-By: PHP/7.2.30-1+ubuntu18.04.1+deb.sury.org+1
Location: http://127.0.0.1:8080/fcrepo/rest/islandora_3_TECHMD.xml
Cache-Control: no-cache, private
Content-Type: text/html; charset=UTF-8
```
- Now go set `drupal_domain` and `fedora_domain` in your `config.yaml` file.  I used these
```
# Leave these blank unless you know what you're doing.  If you're moving
# data from one server to another and the domain changes, set these
# to your new domain.
fedora_domain: fcrepo.example.org
drupal_domain: drupal.example.org
```
- Do the tests again and confirm the urls are rewritten to use the domains you configured
```
$ curl -s -H "Authorization: Bearer islandora" http://localhost:8000/gemini/02862b7c-0a80-45af-bc2a-690a007e40a0 | jq
{
  "drupal": "http://drupal.example.org/_flysystem/fedora/islandora_3_TECHMD.xml",
  "fedora": "http://fcrepo.example.org/fcrepo/rest/islandora_3_TECHMD.xml"
}
$ curl -I -H "X-Islandora-URI: http://drupal.example.org/_flysystem/fedora/islandora_3_TECHMD.xml" -H "Authorization: Bearer islandora" http://localhost:8000/gemini/by_uri
HTTP/1.1 200 OK
Date: Mon, 09 Nov 2020 19:39:25 GMT
Server: Apache/2.4.29 (Ubuntu)
X-Powered-By: PHP/7.2.30-1+ubuntu18.04.1+deb.sury.org+1
Location: http://fcrepo.example.org/fcrepo/rest/islandora_3_TECHMD.xml
Cache-Control: no-cache, private
Content-Type: text/html; charset=UTF-8
```
- **Change your config back to empty strings or the fedora urls will go missing from your objects' displays**
# Additional Notes:
Part of the ongoin ISLE sprint: https://github.com/orgs/Islandora/projects/2

# Interested parties
@Islandora/8-x-committers
