### PR TITLE
chop off charset from mimetype for external content header

### DIFF
--- a/Milliner/src/Service/MillinerService.php
+++ b/Milliner/src/Service/MillinerService.php
@@ -93,7 +93,7 @@ class MillinerService implements MillinerServiceInterface
         $fedora_url  = "$islandora_fedora_endpoint/$path";
 
         $response = $this->fedora->getResourceHeaders($fedora_url);
-        if ($response->getStatusCode() == "404") {
+        if ($response->getStatusCode() == 404) {
             $this->log->debug("GOT A 404");
             return $this->createNode(
                 $jsonld_url,
@@ -324,7 +324,7 @@ class MillinerService implements MillinerServiceInterface
         // Put in an fedora url for the resource.
         $resource[0]['@id'] = $fedora_url;
 
-    
+
         $this->log->debug("AFTER: " . json_encode($resource));
         return $resource;
     }
@@ -481,6 +481,9 @@ class MillinerService implements MillinerServiceInterface
             );
         }
         $mimetype = $drupal_response->getHeader('Content-Type')[0];
+        if (preg_match("/^([^;]+);/", $mimetype, $matches)) {
+            $mimetype = $matches[1];
+        }
 
         // Save it in Fedora as external content.
         $external_rel = "http://fedora.info/definitions/fcrepo#ExternalContent";
@@ -556,6 +559,7 @@ class MillinerService implements MillinerServiceInterface
         $urls = $this->getMediaUrls($source_field, $json_url, $islandora_fedora_endpoint, $token);
         $fedora_url = $urls['fedora'];
 
+        $headers = empty($token) ? [] : ['Authorization' => $token];
         $date = new DateTime();
         $timestamp = $date->format("D, d M Y H:i:s O");
         // create version in Fedora.

--- a/Milliner/tests/Islandora/Milliner/Tests/MillinerControllerTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/MillinerControllerTest.php
@@ -43,7 +43,8 @@ class MillinerControllerTest extends TestCase
      * @covers ::saveNode
      * @covers ::saveMedia
      * @covers ::deleteNode
-     * @covers ::createVersion
+     * @covers ::createNodeVersion
+     * @covers ::createMediaVersion
      */
     public function testMethodsReturnMillinerErrors()
     {


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1918

# What does this Pull Request do?

Checks for a `;` in the `Content-type` header and if it exists, then splits and uses the first part.

Additionally we we're referencing `$headers` in `createMediaVersion` and it was not defined.

Also fixed a bad `@covers` statement

# How should this be tested?

Create a new object, add some media. Check the Milliner logs for the error message like 
> [2021-10-14 15:41:45] app.ERROR:  {"Exception":"[object] (RuntimeException(code: 400): Client error: `PUT http://127.0.0.1:8080/fcrepo/rest/87/3a/d3/68/873ad368-b833-4a95-b1d5-79bdaf05d239` resulted in a `400 Bad Request` response: External content link header url is malformed at /home/vagrant/all_claw/Crayfish/Milliner/src/Service/MillinerService.php:499)"} []

Also there is no record for the media in Fedora.

Pull in this PR and try again.

# Interested parties
@Islandora/8-x-committers
