### PR TITLE
Adds a method to clean up tmp files, if they are still there.

### DIFF
--- a/Houdini/src/Controller/HoudiniController.php
+++ b/Houdini/src/Controller/HoudiniController.php
@@ -115,6 +115,11 @@ class HoudiniController
         $cmd_string = "$this->executable - $args $format:-";
         $this->log->info('Imagemagick Command:', ['cmd' => $cmd_string]);
 
+        // Clean up any tmp files remaining from last run.  In theory there is
+        // nothing, because if something failed it already got cleaned up by the code
+        // below, but it doesn't hurt to do this just in case
+        $this->cleanupTmpFiles();
+
         // Return response.
         try {
             return new StreamedResponse(
@@ -124,6 +129,10 @@ class HoudiniController
             );
         } catch (\RuntimeException $e) {
             $this->log->error("RuntimeException:", ['exception' => $e]);
+
+            // imagemagick leaves temp files behind when it fails,
+            // so there are probably some there now. Clean them up
+            $this->cleanupTmpFiles();
             return new Response($e->getMessage(), 500);
         }
     }
@@ -171,6 +180,31 @@ class HoudiniController
         } catch (\RuntimeException $e) {
             $this->log->error("RuntimeException:", ['exception' => $e]);
             return new Response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * imagemagick will sometimes leave tmp files behind, this will clean them up.
+     * Be careful about when you call this, else you could delete work that's in
+     * progress.
+     */
+     protected function cleanupTmpFiles() {
+
+        // If there's are magick-* or php* files in /tmp, clean them up.
+        // We could just do this, but for now let's add some logging.
+        //   array_map('unlink', glob('/tmp/magick-*'));
+        //   array_map('unlink', glob('/tmp/php*'));
+        try {
+            foreach (glob('/tmp/magick-*') as $filename) {
+                $this->log->info("removing file $filename");
+                unlink($filename);
+            }
+            foreach (glob('/tmp/php*') as $filename) {
+                $this->log->info("removing file $filename");
+                unlink($filename);
+            }
+        } catch (\ErrorException $e) {
+            $this->log->error("ErrorException:", ['exception' => $e]);
         }
     }
 }


### PR DESCRIPTION
Adds code to cleanup tmp files, if there are some there. The tmp files indicate that imagemagick failed in some way and was unable to cleanup its leftover tmp file.   This adds code that will unlink those files, if they exist. 

If we run more than one of these imagemagick processes at a time in the same container, we will need to rethink this, as this method will not work and will interfere with other imagemagick threads running. 

This is just a bandaid really, and maybe not a great one, but should work for iDC right now. 