### PR TITLE
Improved support for Fedora 6 in Milliner

### DIFF
--- a/Milliner/README.md
+++ b/Milliner/README.md
@@ -21,7 +21,7 @@ You will also need an SQL database as needed for [Gemini](../Gemini)
 
 Make a copy of the [config file](cfg/config.example.yaml) and name it `config.yaml` in the `cfg` directory.
 You will need to set the `fedora_base_url` entry to point to your Fedora installation.
-You will also need to set up the `drupal_base_url` entry to point to your Drupal 8 installation.
+You will also need to set up the `drupal_base_url` entry to point to your Drupal 8 installation. Finally, if you are using Fedora 6, you will need to uncomment the `fcrepo6` configuration variable and make sure it is set to `true`.
 The SQL db can be configured by following [Gemini's instructions](../Gemini).
 
 ## Usage
@@ -74,7 +74,7 @@ If you would like to contribute, please get involved by attending our weekly [Te
 
 If you would like to contribute code to the project, you need to be covered by an Islandora Foundation [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Please see the [Contributors](http://islandora.ca/resources/contributors) pages on Islandora.ca for more information.
 
-We recommend using the [islandora-playbook](https://github.com/Islandora-Devops/islandora-playbook) to get started. 
+We recommend using the [islandora-playbook](https://github.com/Islandora-Devops/islandora-playbook) to get started.
 
 ## License
 

--- a/Milliner/README.md
+++ b/Milliner/README.md
@@ -74,8 +74,6 @@ If you would like to contribute, please get involved by attending our weekly [Te
 
 If you would like to contribute code to the project, you need to be covered by an Islandora Foundation [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Please see the [Contributors](http://islandora.ca/resources/contributors) pages on Islandora.ca for more information.
 
-We recommend using the [islandora-playbook](https://github.com/Islandora-Devops/islandora-playbook) to get started.
-
 ## License
 
 [MIT](https://opensource.org/licenses/MIT)

--- a/Milliner/cfg/config.example.yaml
+++ b/Milliner/cfg/config.example.yaml
@@ -5,9 +5,14 @@ fedora_base_url: http://localhost:8080/fcrepo/rest
 # or relative paths will not resolve correctly.
 drupal_base_url: http://localhost:8000
 
+# If using Fedora 6 you must uncomment the following "fcrepo6: true" line,
+# and it must be set to "true" to allow Milliner to properly work with
+# Fedora 6.
+# fcrepo6: true
+
 modified_date_predicate: http://schema.org/dateModified
 
-strip_format_jsonld: true 
+strip_format_jsonld: true
 
 debug: false
 

--- a/Milliner/cfg/config.example.yaml
+++ b/Milliner/cfg/config.example.yaml
@@ -5,9 +5,7 @@ fedora_base_url: http://localhost:8080/fcrepo/rest
 # or relative paths will not resolve correctly.
 drupal_base_url: http://localhost:8000
 
-# If using Fedora 6 you must uncomment the following "fcrepo6: true" line,
-# and it must be set to "true" to allow Milliner to properly work with
-# Fedora 6.
+# Uncomment "fcrepo6: true" to use with Fedora 6+.
 # fcrepo6: true
 
 modified_date_predicate: http://schema.org/dateModified


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2074

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

This PR adds a variable for better support for Fedora 6, by helping the Milliner configuration realize that it will be working with Fedora 6. The PR also adds a small update to the README to explain the small code change. It also removes some trailing spaces found in the config file.

# What's new?


* Added a new configuration variable `fcrepo6: true` to Milliner/cfg/config.example.yaml, that needs to be uncommented if using Fedora 6.
* Also adds a simple explanation to the README that this variable needs to be set to true if using Fedora 6.
* Removed a couple of trailing spaces.

# How should this be tested?

@seth-shaw-unlv may be better at explaining this, but I suspect you must create a Islandora 2 instance with Fedora 6 after you set `fcrepo6: true` and perform some Fedora 6 operations to see the PR work correctly.


# Interested parties
@Islandora/8-x-committers
