### PR TITLE
Allow homarus to use faststart for video conversion

### DIFF
--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -117,7 +117,7 @@ class HomarusController
                 "faststart ";
         }
 
-        $temp_file_path = __DIR__ . "/../../static/" . basename($source) . $format;
+        $temp_file_path = __DIR__ . "/../../static/" . basename($source) . "." . $format;
         $this->log->debug('Tempfile: ' . $temp_file_path);
 
         // Arguments to ffmpeg command are sent as a custom header.

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -146,11 +146,10 @@ class HomarusController
         try {
             $this->cmd->execute($cmd_string, $source);
             return (new BinaryFileResponse(
-              $temp_file_path,
-              200,
-              ['Content-Type' => $content_type]
+                $temp_file_path,
+                200,
+                ['Content-Type' => $content_type]
             ))->deleteFileAfterSend(true);
-
         } catch (\RuntimeException $e) {
             $this->log->error("RuntimeException:", ['exception' => $e]);
             return new Response($e->getMessage(), 500);

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -89,7 +89,7 @@ class HomarusController
 
   /**
    * @param \Symfony\Component\HttpFoundation\Request $request
-   * @return \Symfony\Component\HttpFoundation\Response|\Symfony\Component\HttpFoundation\StreamedResponse
+   * @return \Symfony\Component\HttpFoundation\Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
    */
     public function convert(Request $request)
     {
@@ -133,7 +133,7 @@ class HomarusController
                 400
             );
         }
-      
+
         // Add -loglevel error so large files can be processed.
         $args .= ' -loglevel error';
         $this->log->debug("X-Islandora-Args:", ['args' => $args]);
@@ -143,10 +143,21 @@ class HomarusController
         $this->log->debug('Ffmpeg Command:', ['cmd' => $cmd_string]);
 
         // Return response.
+        return $this->generateDerivativeResponse($cmd_string, $source, $temp_file_path, $content_type);
+    }
+
+    /**
+     * @param string $cmd_string
+     * @param string $source
+     * @param string $path
+     * @param string $content_type
+     * @return \Symfony\Component\HttpFoundation\Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+     */
+    public function generateDerivativeResponse(string $cmd_string, string $source, string $path, string $content_type) {
         try {
             $this->cmd->execute($cmd_string, $source);
             return (new BinaryFileResponse(
-                $temp_file_path,
+                $path,
                 200,
                 ['Content-Type' => $content_type]
             ))->deleteFileAfterSend(true);

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -153,7 +153,8 @@ class HomarusController
      * @param string $content_type
      * @return \Symfony\Component\HttpFoundation\Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    public function generateDerivativeResponse(string $cmd_string, string $source, string $path, string $content_type) {
+    public function generateDerivativeResponse(string $cmd_string, string $source, string $path, string $content_type)
+    {
         try {
             $this->cmd->execute($cmd_string, $source);
             return (new BinaryFileResponse(

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -113,7 +113,7 @@ class HomarusController
         $cmd_params = "";
         if ($format == "mp4") {
             $cmd_params = " -vcodec libx264 -preset medium -acodec aac " .
-                "-strict -2 -ab 128k -ac 2 -async 1 -movflags " .
+                "-strict -2 -ab 128k -ac 2 -async 1 -y -movflags " .
                 "faststart ";
         }
 

--- a/Homarus/tests/Islandora/Homarus/Tests/HomarusControllerTest.php
+++ b/Homarus/tests/Islandora/Homarus/Tests/HomarusControllerTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -219,15 +220,27 @@ class HomarusControllerTest extends TestCase
         $mock_service = $prophecy->reveal();
 
         // Create a controller.
-        $controller = new HomarusController(
-            $mock_service,
-            $this->content_types,
-            $this->default_content_type,
-            'convert',
-            $this->prophesize(Logger::class)->reveal(),
-            $this->mime_to_format,
-            $this->default_format
-        );
+        $controller = $this->getMockBuilder(HomarusController::class)
+            ->onlyMethods(['generateDerivativeResponse'])
+            ->setConstructorArgs([
+                $mock_service,
+                $this->content_types,
+                $this->default_content_type,
+                'convert',
+                $this->prophesize(Logger::class)->reveal(),
+                $this->mime_to_format,
+                $this->default_format,
+            ])
+            ->getMock();
+
+        $controller->method('generateDerivativeResponse')
+            ->will($this->returnCallback(function ($cmd_string, $source, $path, $content_type) {
+                return new BinaryFileResponse(
+                    __DIR__ . "/../../../fixtures/foo.mp4",
+                    200,
+                    ['Content-Type' => $content_type]
+                );
+            }));
         return $controller;
     }
 


### PR DESCRIPTION
**GitHub Issue**: (link)
https://github.com/Islandora/documentation/issues/2162

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
https://stackoverflow.com/questions/64661989/chrome-video-tag-cant-play-fragmented-mp4-stream
https://gitlab.com/Shinobi-Systems/Shinobi/-/issues/237
https://gitlab.com/Shinobi-Systems/Shinobi/-/issues/66

# What does this Pull Request do?
Replaces the moveflags frag_keyframe+empty_moov with faststart

A brief description of what the intended result of the PR will be and/or what problem it solves.
It allows videos to be played instantly on all browsers. On chrome large fragmented videos take too long to play.

# What's new?

* Remove moveflags frag_keyframe+empty_moov
* Added moveflags faststart
* Converted file is saved as a tempfile - It is not possible to stream output with faststart.
* The response has changed from StreamResponse to BinaryFileResponse

# How should this be tested?

* Ingest a large video file preferably mov and wait for derivative generation. Now try to play this file on chrome. There are multiple 206 partial content network requests and video starts playing after the moov atom for each fragment has been loaded.
* Now try the same with this PR. The video will start playing instantly.

# Additional Notes:
Open to suggestions about alternate solutions but I've searched everywhere and couldn't find anything else that works.

# Interested parties
@Islandora/committers  @Islandora/8-x-committers @adam-vessey @lutaylor @willtp87 @jordandukart 
