### PR TITLE
Passthrough the configured MIME.

### DIFF
--- a/Hypercube/src/Controller/HypercubeController.php
+++ b/Hypercube/src/Controller/HypercubeController.php
@@ -89,7 +89,7 @@ class HypercubeController
             return new StreamedResponse(
                 $this->cmd->execute($cmd_string, $body),
                 200,
-                ['Content-Type' => 'text/plain']
+                ['Content-Type' => $request->headers->get('Accept') ?? 'text/plain']
             );
         } catch (\RuntimeException $e) {
             return new Response($e->getMessage(), 500);


### PR DESCRIPTION
# What does this Pull Request do?

Allows a configured MIME type from an Islandora action to be passed through to Hypercube.

# What's new?
The MIME type of `text/plain` is no longer hardcoded and a configured MIME type is now used.

# How should this be tested?
Create an action that uses Hypercube (OCR, hOCR) and specify a MIME type that isn't `text/plain`. 

Ingest an object and media that will create a derivative with Hypercube to be triggered (for example a book, pages and media).

The resultant `File` entities within Drupal have the set MIME type that matches the one configured.

# Interested parties
@Islandora/8-x-committers
