### PR TITLE
Use parse_url to drop query string before creating derivative filename

### DIFF
--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -119,7 +119,7 @@ class HomarusController
                 "faststart -y";
         }
 
-        $temp_file_path = $this->tempDirectory . basename($source) . "." . $format;
+        $temp_file_path = $this->tempDirectory . basename(parse_url($source, PHP_URL_PATH)) . "." . $format;
         $this->log->debug('Tempfile: ' . $temp_file_path);
 
         // Arguments to ffmpeg command are sent as a custom header.


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?

We use cloudfront for our publically accessible files, but they often include absurdly long query strings. Homarus attempts to use the full query string as a temp filename which can throw errors. This PR uses `parse_url` to grab the path without the query string so we can avoid that issue.

# How should this be tested?

- Send a convert request for a file such as `https://d1rbsgppyrdqq4.cloudfront.net/s3fs-public/c2/SchoolOfDance_GraduateShow_20120405_WhatAPieceOfWorkIsAMan.mov?versionId=sggFBmGMpYex.4.u321PJgTJjpt5HuuI&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIASBVQ3ZQ42ZLA5CUJ/20231002/us-west-2/s3/aws4_request&X-Amz-Date=20231002T180834Z&X-Amz-SignedHeaders=host&X-Amz-Expires=120&X-Amz-Signature=6728303d099497f989b99dcae274da3072c0f82737d81e3a1b5584dd6fb35f05` and see an error thrown in the logs: `crayfish.cmd_execute_service.ERROR: Process exited with non-zero code. {"exit_code":1,"stderr":"/var/www/html/Crayfish/Homarus/src/Controller/../../static/SchoolOfDance_GraduateShow_20120405_WhatAPieceOfWorkIsAMan.mov?versionId=sggFBmGMpYex.4.u321PJgTJjpt5HuuI&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIASBVQ3ZQ42ZLA5CUJ%2F20231002%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20231002T181347Z&X-Amz-SignedHeaders=host&X-Amz-Expires=120&X-Amz-Signature=07b6b42d1bd914405d4a65fd2d9ecc9827a54a6a07af69862c8bb1bde5fc17bd.mp4: File name too long\n"} []
[2023-10-02 18:13:53] app.ERROR: RuntimeException: {"exception":"[object] (RuntimeException(code: 500): /var/www/html/Crayfish/Homarus/src/Controller/../../static/SchoolOfDance_GraduateShow_20120405_WhatAPieceOfWorkIsAMan.mov?versionId=sggFBmGMpYex.4.u321PJgTJjpt5HuuI&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIASBVQ3ZQ42ZLA5CUJ%2F20231002%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20231002T181347Z&X-Amz-SignedHeaders=host&X-Amz-Expires=120&X-Amz-Signature=07b6b42d1bd914405d4a65fd2d9ecc9827a54a6a07af69862c8bb1bde5fc17bd.mp4: File name too long\n at /var/www/html/Crayfish/Homarus/vendor/islandora/crayfish-commons/src/CmdExecuteService.php:120)"} []`
- Apply the PR
- Send the request again and get the derivative you asked for.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
