### PR TITLE
Update FITS project URL, old URL restricted to Harvard sign-ins

### DIFF
--- a/CrayFits/README.md
+++ b/CrayFits/README.md
@@ -13,9 +13,9 @@
 
 ### Install FITS webservice
 
-* Download the latest `fits.zip` and `fits.war` from
-[https://github.com/harvard-lts/fits/releases](https://github.com/harvard-lts/fits/releases).
+* Download the latest `fits.zip` from [harvard-lts/fits project releases][3].
 You may need to install a zip library to unzip the file.
+* Download the latest `fits.war` from [harvard-lts/FITS-servlet project releases][4]
 * Copy the `.war` file to your Tomcat webapps directory and test.
 * Edit the Tomcat `conf/catalina.properties` file by adding the
 following two lines to the bottom of the file:
@@ -62,5 +62,5 @@ appropriate to your installation of CrayFits.
 
 [1]: https://harvard-lts.github.io/fits/
 [2]: https://getcomposer.org/download/
-
-
+[3]: https://github.com/harvard-lts/fits/releases
+[4]: https://github.com/harvard-lts/FITSservlet/releases

--- a/CrayFits/README.md
+++ b/CrayFits/README.md
@@ -14,7 +14,7 @@
 ### Install FITS webservice
 
 * Download the latest `fits.zip` and `fits.war` from
-[https://projects.iq.harvard.edu/fits/downloads](https://projects.iq.harvard.edu/fits/downloads).
+[https://github.com/harvard-lts/fits/releases](https://github.com/harvard-lts/fits/releases).
 You may need to install a zip library to unzip the file.
 * Copy the `.war` file to your Tomcat webapps directory and test.
 * Edit the Tomcat `conf/catalina.properties` file by adding the
@@ -60,7 +60,7 @@ To use Alpaca as an interface to this microservice, configure
 an [`islandora-connector-derivative`](https://github.com/Islandora/Alpaca#islandora-connector-derivative)
 appropriate to your installation of CrayFits.
 
-[1]: https://projects.iq.harvard.edu/fits
+[1]: https://harvard-lts.github.io/fits/
 [2]: https://getcomposer.org/download/
 
 


### PR DESCRIPTION
**GitHub Issue**: just this PR, happy to open one if issue required :)

# What does this Pull Request do?

The links to FITS project in https://github.com/Islandora/Crayfish/tree/4.x/CrayFits were not accessible as a Harvard account was required to view the URLs.

# What's new?

This PR changes the README to point to what appears to be the new project website.

# How should this be tested?

Check links in old and new version of document.

# Additional Notes:

Slack thread here: https://islandora.slack.com/archives/CM5PPAV28/p1748388357101529 - contains no additional information at time of writing 😉 

# Interested parties

@Islandora/8-x-committers
